### PR TITLE
Indexing fails when there is an object relation or object relations attribute that contains a trashed object

### DIFF
--- a/classes/ezfsolrdocumentfieldobjectrelation.php
+++ b/classes/ezfsolrdocumentfieldobjectrelation.php
@@ -263,7 +263,7 @@ class ezfSolrDocumentFieldObjectRelation extends ezfSolrDocumentFieldBase
                 $returnArray[$defaultFieldName] = $this->getPlainTextRepresentation();
                 $relatedObject = $this->ContentObjectAttribute->content();
 
-                if ( $relatedObject && $relatedObject->Status === 1 )
+                if ( $relatedObject && $relatedObject->attribute( 'status' ) == eZContentObject::STATUS_PUBLISHED )
                 {
                     // 1st, add content fields of the related object.
                     $baseList = $this->getBaseList( $relatedObject->attribute( 'current' ) );


### PR DESCRIPTION
Patch uses the same checks as:

design/standard/templates/content/datatype/edit/ezobjectrelation.tpl
design/standard/templates/content/datatype/edit/ezobjectrelationlist.tpl
