### PR TITLE
Removed sort, facet and filter datatype mapings for ezstring

### DIFF
--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -102,7 +102,7 @@ DatatypeMap[ezboolean]=boolean
 DatatypeMap[ezdate]=date
 DatatypeMap[ezdatetime]=date
 DatatypeMap[ezfloat]=sfloat
-DatatypeMap[ezinteger]=sint
+DatatypeMap[ezinteger]=string
 DatatypeMap[ezprice]=sfloat
 DatatypeMap[eztime]=date
 DatatypeMap[ezkeyword]=lckeyword
@@ -127,7 +127,6 @@ DatatypeMapFacet[]
 DatatypeMapFilter[]
 #DatatypeMapFilter[ezstring]=simpletext
 #DatatypeMapFilter[ezkeyword]=lckeyword
-
 
 # Default field type
 Default=text


### PR DESCRIPTION
Removed sort, facet and filter datatype mapings for ezstring because the search is not working with it.
