### PR TITLE
Support for custom solr query parameters in fetch functions

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -165,7 +165,7 @@ class ezfeZPSolrQueryBuilder
         $distributedSearch = isset( $params['DistributedSearch'] ) ? $params['DistributedSearch'] : false;
         $fieldsToReturn = isset( $params['FieldsToReturn'] ) ? $params['FieldsToReturn'] : array();
         $highlightParams = isset( $params['HighLightParams'] ) ? $params['HighLightParams'] : array();
-
+        $customQueryParams = isset( $params['CustomQueryParams'] ) ? $params['CustomQueryParams'] : array();
 
         // distributed search option
         // @since ezfind 2.2
@@ -481,7 +481,8 @@ class ezfeZPSolrQueryBuilder
             $facetQueryParamList,
             $spellCheckParamList,
             $boostFunctionsParamList,
-            $elevateParamList
+            $elevateParamList,
+            $customQueryParams
         );
         return $queryParams;
     }
@@ -666,6 +667,7 @@ class ezfeZPSolrQueryBuilder
         $subtrees = isset( $params['SearchSubTreeArray'] ) ? $params['SearchSubTreeArray'] : array();
         $contentClassID = ( isset( $params['SearchContentClassID'] ) && $params['SearchContentClassID'] <> -1 ) ? $params['SearchContentClassID'] : false;
         $sectionID = isset( $params['SearchSectionID'] ) && $params['SearchSectionID'] > 0 ? $params['SearchSectionID'] : false;
+        $customQueryParams = isset( $params['CustomQueryParams'] ) ? $params['CustomQueryParams'] : array();
         $filterQuery = array();
 
 
@@ -803,7 +805,8 @@ class ezfeZPSolrQueryBuilder
                 ' score ' . eZSolr::getMetaFieldName( 'published' ) . ' ' . eZSolr::getMetaFieldName( 'path_string' ),
                 'fq' => $filterQuery,
                 'wt' => 'php' ),
-            $facetQueryParamList );
+            $facetQueryParamList,
+            $customQueryParams );
 
         return $queryParams;
     }

--- a/classes/ezfmodulefunctioncollection.php
+++ b/classes/ezfmodulefunctioncollection.php
@@ -106,7 +106,8 @@ class ezfModuleFunctionCollection
     public function search( $query, $offset = 0, $limit = 10, $facets = null,
                             $filters = null, $sortBy = null, $classID = null, $sectionID = null,
                             $subtreeArray = null, $ignoreVisibility = false, $limitation = null, $asObjects = true, $spellCheck = null, $boostFunctions = null, $queryHandler = 'ezpublish',
-                            $enableElevation = true, $forceElevation = false, $publishDate = null, $distributedSearch = null, $fieldsToReturn = null )
+                            $enableElevation = true, $forceElevation = false, $publishDate = null, $distributedSearch = null, $fieldsToReturn = null,
+                                  $customQueryParams = null )
     {
         $solrSearch = new eZSolr();
         $params = array( 'SearchOffset' => $offset,
@@ -127,7 +128,8 @@ class ezfModuleFunctionCollection
                          'ForceElevation' => $forceElevation,
                          'SearchDate' => $publishDate,
                          'DistributedSearch' => $distributedSearch,
-                         'FieldsToReturn' => $fieldsToReturn );
+                         'FieldsToReturn' => $fieldsToReturn,
+                         'CustomQueryParams' => $customQueryParams );
         return array( 'result' => $solrSearch->search( $query, $params ) );
     }
 
@@ -170,7 +172,8 @@ class ezfModuleFunctionCollection
      */
     public function moreLikeThis( $queryType, $query, $offset = 0, $limit = 10, $facets = null,
                                   $filters = null, $sortBy = null, $classID = null, $sectionID = null,
-                                  $subtreeArray = null, $asObjects = true, $queryInstallationID = null )
+                                  $subtreeArray = null, $asObjects = true, $queryInstallationID = null,
+                                  $customQueryParams = null )
 
     {
         $solrSearch = new eZSolr();
@@ -183,7 +186,8 @@ class ezfModuleFunctionCollection
                          'SearchSectionID' => $sectionID,
                          'SearchSubTreeArray' => $subtreeArray,
                          'QueryInstallationID' => $queryInstallationID,
-                         'AsObjects' => $asObjects);
+                         'AsObjects' => $asObjects,
+                         'CustomQueryParams' => $customQueryParams );
         return array( 'result' => $solrSearch->moreLikeThis( $queryType, $query, $params ) );
 
 

--- a/modules/ezfind/function_definition.php
+++ b/modules/ezfind/function_definition.php
@@ -115,6 +115,10 @@ $FunctionList['search'] = array( 'name' => 'search',
                                                         array ( 'name'  => 'fields_to_return',
                                                                 'type' => 'array',
                                                                 'required' => false,
+                                                                'default' => null ),
+                                                        array ( 'name'  => 'custom_query_params',
+                                                                'type' => 'array',
+                                                                'required' => false,
                                                                 'default' => null )) );
 
 
@@ -215,7 +219,11 @@ $FunctionList['moreLikeThis'] = array( 'name' => 'moreLikeThis',
                                                         array( 'name' => 'query_installation_id',
                                                                'type' => 'string',
                                                                'required' => false,
-                                                               'default' => null ) ) );
+                                                               'default' => null ),
+                                                        array ( 'name'  => 'custom_query_params',
+                                                                'type' => 'array',
+                                                                'required' => false,
+                                                                'default' => null ) ) );
 
 $FunctionList['elevateConfiguration'] = array(   'name' => 'elevateConfiguration',
                                                  'operation_types' => 'read',


### PR DESCRIPTION
Hi, 
I was working on fetching the nearest contents based on a geopoint field but found out there was no way to pass Solr the required query parameters through eZFind without going with a raw request, thus losing standard parameters and automatic filters.

So I came out with this solution to set custom query params in the fetch function parameters. For instance, here's my geolocation fetch :

```
{def $near = fetch( 'ezfind', 'search', hash(
    'limit', 3,
    'filter', array(
       concat( '-meta_id_si:', $node.object.id ),
       'attr_geolocalisation_gpt:[-90,-90 TO 90,90]'
    ),
    'custom_query_params', hash(
        'sfield', 'attr_geolocalisation_gpt',
        'pt', concat( $node.data_map.geolocalisation.content.centroid_lat, ',', $node.data_map.geolocalisation.content.centroid_lng )
    ),
    'sort_by', hash( 'geodist()', 'asc' )
))}
```
