### PR TITLE
Add aggregate field to schema for keywords

### DIFF
--- a/java/solr/conf/schema.xml
+++ b/java/solr/conf/schema.xml
@@ -676,6 +676,7 @@
 
 
       <field name="ezf_df_text" type="text"    indexed="true"  stored="true" multiValued="true" termVectors="true"/>
+      <field name="ezf_df_tags" type="lckeyword" indexed="true" stored="true" multiValued="true" termVectors="true"/>
 
    <!-- uncomment the following to ignore any fields that don't already match an existing
         field name or dynamic field, rather than reporting them as an error.
@@ -708,6 +709,8 @@
     <copyField source="*_k" dest="ezf_sp_words"/>
     <copyField source="*_t" dest="ezf_sp_words"/>
     <copyField source="*_s" dest="ezf_sp_words"/>
+    <copyField source="*_lk" dest="ezf_df_tags"/>
+    <copyField source="*_k" dest="ezf_df_tags"/>
 
 
    <!-- Above, multiple source fields are copied to the [text] field.


### PR DESCRIPTION
Since eZ Tags is the first candidate extension for inclusion in one of the next eZ Publish Community Project builds (http://share.ez.no/blogs/community-project-board/taking-the-community-project-one-step-further-bundling-community-extensions) and it uses this field for simple tag suggestions, I'm creating the pull request for you to review.

It would simplify the installation of extension as there wouldn't be need to modify schema.xml by hand.
