### PR TITLE
ezmatrixSolrStorage: Avoid "undefined index" warning

### DIFF
--- a/classes/solrstorage/ezmatrixsolrstorage.php
+++ b/classes/solrstorage/ezmatrixsolrstorage.php
@@ -31,8 +31,13 @@ class ezmatrixSolrStorage extends ezdatatypeSolrStorage
 
         for ( $i = 0; $i < count( $cellList ); $i++ )
         {
+            $key = $cellList[$i];
+            $j = ++$i;
 
-            $availableCells[] = array( $cellList[$i] => $cellList[++$i] );
+            if ( isset( $cellList[$j] ) )
+            {
+                $availableCells[] = array( $key => $cellList[$j] );
+            }
         }
 
         $target = array(


### PR DESCRIPTION
Greeetings!

While re-creating my local Solr Index, some problems crossed my path.

In this snippet, `++$i` always becomes greater than `count( $cellList )` and throws a warning.

Best
- Jérôme
