### PR TITLE
Delete useless html comments, that crashs minifier

### DIFF
--- a/design/admin2/templates/page_search.tpl
+++ b/design/admin2/templates/page_search.tpl
@@ -43,7 +43,6 @@ ezAutoHeader.init({ldelim}
 
 {rdelim});
 
-<!--
 {literal}
 (function($) {
 	if ( document.getElementById('searchbuttonfield') ) {
@@ -57,6 +56,5 @@ ezAutoHeader.init({ldelim}
     }
 })( jQuery );
 {/literal}
-// -->
 </script>
 {undef $search_node_id}


### PR DESCRIPTION
Just deleting a comment that is at a wrong place, and crashes my minifier

The fact is <!-- is wrong strictly speaking, it should be //<!--

But as there's a move towards html5, that doesn't need anymore wrapper (<!-- or cdata), this commit just clean those...
