### PR TITLE
Emit every attributes from Solr when IsObject not requested

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -937,14 +937,13 @@ class eZSolr implements ezpSearchEngine
                     foreach ( $doc as $fieldName => $fieldValue )
                     {
                         list( $prefix, $rest ) = explode( '_', $fieldName, 2 );
-                        if ( $prefix === 'meta' )
+                        if ( $prefix === 'as' )
                         {
-                            $emit[$rest] = $fieldValue;
-                        }
-                        elseif ( $prefix === 'as' )
-                        {
-
                             $emit['data_map'][substr( $rest,0, -4 )] = ezfSolrStorage::unserializeData( $fieldValue );
+                        }
+                        else
+                        {
+                            $emit[$fieldName] = $fieldValue;
                         }
 
                     }


### PR DESCRIPTION
This commit is related to this topic : http://share.ez.no/forums/extensions/ez-find-fieldstoreturn

When calling ezfind fetch with as_object = false only fields starting with meta_ are returned. The problem is this as_object switch is very useful to avoid unecessary mysql calls to improve significantly performance. 

With this pull request we solve this problem and give access to every attributes in SolR index.
