### PR TITLE
issue #019318 : Adding field in schema.xml for specifying priority as multivalued

### DIFF
--- a/java/solr.multicore/eng-GB/conf/schema.xml
+++ b/java/solr.multicore/eng-GB/conf/schema.xml
@@ -609,6 +609,7 @@
    <field name="meta_view_count_si" type="sint" indexed="true" stored="true" multiValued="true"/>  <!-- View count -->
    <field name="meta_is_hidden_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
    <field name="meta_is_invisible_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
+   <field name="meta_priority_si" type="sint" indexed="true" stored="true" multiValued="true"/>
 
 
    <!-- Here, default is used to create a "timestamp" field indicating

--- a/java/solr.multicore/fre-FR/conf/schema.xml
+++ b/java/solr.multicore/fre-FR/conf/schema.xml
@@ -608,6 +608,7 @@
    <field name="meta_view_count_si" type="sint" indexed="true" stored="true" multiValued="true"/>  <!-- View count -->
    <field name="meta_is_hidden_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
    <field name="meta_is_invisible_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
+   <field name="meta_priority_si" type="sint" indexed="true" stored="true" multiValued="true"/>
 
 
    <!-- Here, default is used to create a "timestamp" field indicating

--- a/java/solr.multicore/nor-NO/conf/schema.xml
+++ b/java/solr.multicore/nor-NO/conf/schema.xml
@@ -609,6 +609,7 @@
    <field name="meta_view_count_si" type="sint" indexed="true" stored="true" multiValued="true"/>  <!-- View count -->
    <field name="meta_is_hidden_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
    <field name="meta_is_invisible_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
+   <field name="meta_priority_si" type="sint" indexed="true" stored="true" multiValued="true"/>
 
 
    <!-- Here, default is used to create a "timestamp" field indicating

--- a/java/solr/conf/schema.xml
+++ b/java/solr/conf/schema.xml
@@ -608,6 +608,7 @@
    <field name="meta_view_count_si" type="sint" indexed="true" stored="true" multiValued="true"/>  <!-- View count -->
    <field name="meta_is_hidden_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
    <field name="meta_is_invisible_b" type="boolean" indexed="true" stored="true" multiValued="true"/>
+   <field name="meta_priority_si" type="sint" indexed="true" stored="true" multiValued="true"/>
 
 
    <!-- Here, default is used to create a "timestamp" field indicating


### PR DESCRIPTION
Adding field in solr's schemas for specifying priority meta field as multivalued and resolving indexing failures on nodes with multiple locations.

See issue #019318.
