### PR TITLE
Add support for localparams for queries

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -989,7 +989,7 @@ class ezfeZPSolrQueryBuilder
                     $baseNameInfo = eZSolr::getFieldName( $baseName, true, 'filter' );
                     if ( is_array( $baseNameInfo ) and isset( $baseNameInfo['contentClassId'] ) )
                     {
-                        $filterQueryList[] = '( ' . eZSolr::getMetaFieldName( 'contentclass_id' ) . ':' . $baseNameInfo['contentClassId'] . ' AND ' . $baseNameInfo['fieldName'] . ':' . $value . ' )' ;
+                        $filterQueryList[] = $baseNameInfo['localVars'] . '( ' . eZSolr::getMetaFieldName( 'contentclass_id' ) . ':' . $baseNameInfo['contentClassId'] . ' AND ' . $baseNameInfo['fieldName'] . ':' . $value . ' )' ;
                     }
                     else
                     {

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -190,6 +190,12 @@ class eZSolr implements ezpSearchEngine
      */
     static function getFieldName( $baseName, $includingClassID = false, $context = 'search' )
     {
+        $localVars = "";
+        if (preg_match('/^(\{[^}]+\})(.+)$/', $baseName, $matches)) {
+            $baseName  = array_pop($matches);
+            $localVars = array_pop($matches);
+        }
+        
         // If the base name is a meta field, get the correct field name.
         if ( eZSolr::hasMetaAttributeType( $baseName, $context ) )
         {
@@ -247,10 +253,11 @@ class eZSolr implements ezpSearchEngine
             if ( $includingClassID )
             {
                 return array( 'fieldName'      => $fieldName,
-                              'contentClassId' => $contentClassAttribute->attribute( 'contentclass_id' ) );
+                              'contentClassId' => $contentClassAttribute->attribute( 'contentclass_id' ),
+                              'localVars'      => $localVars );
             }
             else
-                return $fieldName;
+                return $localVars . $fieldName;
         }
     }
 


### PR DESCRIPTION
Add support for local params as described in http://wiki.apache.org/solr/LocalParams

This allows for tagging queries for faceting ( http://wiki.apache.org/solr/SimpleFacetParameters#Multi-Select_Faceting_and_LocalParams )

``` smarty
        {def $search_data = fetch(
                'ezfind', 'search', hash(
                    'query',    '*:*',
                    'class_id', 'artwork',
                    'limit',    $searchCountData.SearchCount,
                    'facet',  array(
                        hash(
                            'field',   '{!ex=am\}artwork/medium',
                        ),
                    ),
                    'filter', $searchFilter,
                    'group', hash(
                        'field',    '{!tag=am\}artwork/medium',
                        'truncate', 'true',
                        'main',     'true',
                    ),
                )
            )
        }
```
