### PR TITLE
Html entities decode

### DIFF
--- a/classes/ezfsolrdocumentfieldxml.php
+++ b/classes/ezfsolrdocumentfieldxml.php
@@ -80,7 +80,7 @@ class ezfSolrDocumentFieldXML extends ezfSolrDocumentFieldBase
             $text );
         $text = strip_tags( $text );
 
-        return html_entity_decode( $text, ENT_QUOTES|ENT_HTML401, 'UTF-8' );
+        return html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
     }
 
 


### PR DESCRIPTION
Hi,
short patch not to index HTML entities in SolR.

Typical use case : an HTML table with empty cells in an ezxmltext attribute. `&nbsp;` entities are indexed and then restituted in highlight query result.

I assumed encoding was always UTF-8, please tell me if I'm wrong.
