### PR TITLE
Aligned the solr init script with the skeleton provided in Debian 6

### DIFF
--- a/bin/scripts/debian/solr
+++ b/bin/scripts/debian/solr
@@ -1,122 +1,121 @@
-#!/bin/sh -e
+#! /bin/sh
 #
 # eZ Find init script for debian.
 #
 # Usage:
 #
-# Set the correct SOLR_HOME value, and copy this file to /etc/init.d, then
-# - either run "update-rc.d solr defaults"
-# - or symlink by hand /etc/init.d/solr to /etc/rc<n>.d/S70solr and /etc/rc<n>.d/K70solr
-#
-# Example:
-# cp solr /etc/init.d/solr
-# cd /etc/init.d && chmod 755 solr
-# cd /etc/rc2.d && ln -s ../init.d/solr S70solr
-# cd /etc/rc5.d && ln -s ../init.d/solr S70solr
-# cd /etc/rc2.d && ln -s ../init.d/solr K70solr
-# cd /etc/rc5.d && ln -s ../init.d/solr K70solr
-#
+# Set the correct SOLR_HOME value, and copy (or symlink) this file to
+# /etc/init.d, then run "update-rc-d solr defaults" as root
+
 ### BEGIN INIT INFO
 # Provides:          solr
 # Required-Start:    $local_fs $remote_fs
 # Required-Stop:     $local_fs $remote_fs
-# Should-Start:      $all
-# Should-Stop:       $all
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: Start/stop Solr
-# Description:       Start/stop Solr
+# Short-Description: Start/stop solr
+# Description:       Start/stop solr
 ### END INIT INFO
 
-. /lib/lsb/init-functions
+# Replace with the java directory of your eZ Find extension
+# (example: /var/www/ezpublish/extension/ezfind/java)
+SOLR_HOME=/usr/local/solr/java
 
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Solr indexing server"
 NAME=solr
-SOLR_HOME=/usr/local/solr/java
-#Replace with the java directory of your eZFind extension (example: /var/www/ezpublish/extension/ezfind/java)
-
-PARAMETERS="-jar start.jar"
 DAEMON=/usr/bin/java
+DAEMON_ARGS="-jar start.jar"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Gracefully exit if the package has been removed.
-test -x $DAEMON || exit 0
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+# and status_of_proc is working.
+. /lib/lsb/init-functions
 
 #
-#	Function that starts the daemon/service.
+# Function that starts the daemon/service
 #
-d_start() {
-	start-stop-daemon --start --pidfile $PIDFILE --chdir $SOLR_HOME --background --make-pidfile --exec $DAEMON -- $PARAMETERS
-}
-#
-#	Function that stops the daemon/service.
-#
-d_stop() {
-	start-stop-daemon --stop --quiet --pidfile $PIDFILE --name java
-        rm -f $PIDFILE
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test -- $DAEMON_ARGS > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --chdir $SOLR_HOME --background --make-pidfile --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
+    sleep 2
 }
 
 #
-#	Function that checks if solr is running
-#	Returns success (0) if solr is running, failure (1) if not running
+# Function that stops the daemon/service
 #
-d_status() {
-    if [ -f "$PIDFILE" ] && ps `cat $PIDFILE` >/dev/null 2>&1; then
-		return 0 # EXIT_SUCCESS
-    else
-	  	return 1 # EXIT_FAILURE
-    fi
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	rm -f $PIDFILE
+	return "$RETVAL"
 }
 
 case "$1" in
   start)
-	echo " * Starting $DESC: $NAME"
-	if d_status; then
-		echo "   ...$NAME is already running."
-		return 1
-	fi
-	d_start
-	if d_status; then
-		echo "   ...done."
-	else
-		echo "   ...failed to start solr"
-		exit 1
-	fi
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
 	;;
   stop)
-	echo " * Stopping $DESC: $NAME"
-	if d_status; then
-		d_stop
-		if d_status; then
-			echo "   ...$NAME is still running."
-			exit 1
-		else
-			echo "   ...done."
-		fi
-	else
-		echo "   ...$NAME is not running."
-	fi
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
 	;;
   status)
-	if d_status; then
-		echo " * $NAME is running (PID: `cat $PIDFILE`)"
-	else
-		echo " * $NAME is not running."
-	fi
-	;;
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
   restart|force-reload)
-	echo -n "Restarting $DESC: $NAME"
-	d_stop
-	sleep 1
-	d_start
-	echo "."
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
 	;;
   *)
-	echo "Usage: $SCRIPTNAME {start|stop|restart|force-reload}" >&2
-	exit 1
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
 	;;
 esac
 
-exit 0
+:


### PR DESCRIPTION
Update of the init.d script to start Solr on Debian based system. The current one displays `...failed to start solr` even if it actually starts correctly Solr and in addition, it does not follow the current conventions of init.d scripts (mostly the VERBOSE parameter set in /etc/default/rcS)
