### PR TITLE
Fixed #19445: Stop words are preventing searches from returning results

### DIFF
--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -122,11 +122,11 @@ DatatypeMap[ezboolean]=boolean
 DatatypeMap[ezdate]=date
 DatatypeMap[ezdatetime]=date
 DatatypeMap[ezfloat]=sfloat
-DatatypeMap[ezinteger]=string
+DatatypeMap[ezinteger]=text
 DatatypeMap[ezprice]=sfloat
 DatatypeMap[eztime]=date
 DatatypeMap[ezkeyword]=lckeyword
-DatatypeMap[ezselection]=string
+DatatypeMap[ezselection]=text
 
 
 # Since ez find 2.2
@@ -136,6 +136,7 @@ DatatypeMap[ezselection]=string
 DatatypeMapSort[]
 DatatypeMapSort[ezstring]=string
 DatatypeMapSort[ezinteger]=sint
+DatatypeMapSort[ezselection]=string
 
 # Since ez find 2.2
 # For facets, the mapping is also tbe re-used for facet filters
@@ -145,11 +146,13 @@ DatatypeMapFacet[]
 #DatatypeMapFacet[ezstring]=simpletext
 #DatatypeMapFacet[ezkeyword]=lckeyword
 DatatypeMapFacet[ezinteger]=tint
+DatatypeMapFacet[ezselection]=string
 
 DatatypeMapFilter[]
 #DatatypeMapFilter[ezstring]=simpletext
 #DatatypeMapFilter[ezkeyword]=lckeyword
 DatatypeMapFilter[ezinteger]=tint
+DatatypeMapFilter[ezselection]=string
 
 
 


### PR DESCRIPTION
(Our reviewboard seems to not work correctly for the moment, that's why I'm creating this pull request)
# Description:

In some cases, if your search request contains one or several stop words, there's no result even if the search without the stop words returns something. This happens if you have defined a content class with an integer or an ezselection attribute that is indexed because those attributes are indexed in a "string" field in Solr and the "string" fields are not analyzed with the solr.StopFilterFactory filter in schema.xml. As a result, the stop words are still used to search on those attributes so it becomes impossible to satisfy the "Mininmum should match" (mm)  parameter of the ezpublish request handler (dismax) in some cases.

For instance, if you search "autosave getting started", you'll get 3 results with the demo content, but "autosave getting started stopworda stopwordb" returns nothing because "stopworda" and "stopwordb" are stop words (!) and with the current settings they are still used to search. It becomes then impossible to satisfy the mm setting of the ezpublish request handler which says that for a request with 5 terms, the resulting documents should at least match for 4 of them.

This patch changes the configuration for integer and ezselection so that those datatypes are indexed in a "text" field and also defined DatatypeMapSort, DatatypeMapFacet and DatatypeMapFilter to not add a BC break on sorting, faceting or filtering on ezselection attributes.
# Testing done:

search with stopwords but also "normal" search on ezselection and integer attributes.
