### PR TITLE
Fixed #017717: Multicore: Fatal Error on direct calls to eZSolr::commit()

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -761,7 +761,7 @@ class eZSolr implements ezpSearchEngine
         {
             foreach ( $this->SolrLanguageShards as $shard )
             {
-                $shard->Solr->commit();
+                $shard->commit();
             }
         }
         else


### PR DESCRIPTION
The fix is needed for delayed indexing in a multicore environment. See also: http://issues.ez.no/17717
