### PR TITLE
Fixed issue 19226: Auto-complete error in Administration Interface 

### DIFF
--- a/classes/ezfindservercallfunctions.php
+++ b/classes/ezfindservercallfunctions.php
@@ -112,7 +112,7 @@ class eZFindServerCallFunctions
         $findINI = eZINI::instance( 'ezfind.ini' );
 
         // Only make calls if explicitely enabled
-        if ($findINI->variable('AutoCompleteSettings', 'AutoComplete') === 'enabled')
+        if ( $findINI->variable( 'AutoCompleteSettings', 'AutoComplete' ) === 'enabled' )
         {
 
             $solrINI = eZINI::instance( 'solr.ini' );

--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -66,6 +66,9 @@ LanguagesCoresMap[]
 
 [AutoCompleteSettings]
 # Enables or disables autocomplete feature
+# Note: you better set this per siteaccess when its really intended to be used as
+# it may put significant extra load on the search server
+# See also the FacetMethod setting for performance
 #AutoComplete=enabled
 # The maximum number of suggestions to return from search engine.
 Limit=10


### PR DESCRIPTION
causes searching to hang on big indexes

Patch now honors settings and also adds a facet method setting in ezfind.ini
