### PR TITLE
Including commitwithin attribute to delete doc.

### DIFF
--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -361,6 +361,8 @@ class eZSolrBase
      *              $query will be used to delete documents instead.
      * @param string $query Solr Query. This will be ignored if $docIDs is set.
      * @param bool $optimize set to true to perform a solr optimize after delete
+     * @param integer $commitWithin specifies within how many milliseconds a commit should occur if no other commit
+     *       is triggered in the meantime (Solr 1.4, eZ Find 2.2)
      * @return bool
      **/
     function deleteDocs ( $docIDs = array(), $query = false, $commit = true,  $optimize = false, $commitWithin = 0 )


### PR DESCRIPTION
Solr can now accept commitwithin for deletes.

Adding inclusion of commitwithin attribute for deletes in ezFind.

See https://issues.apache.org/jira/browse/SOLR-2280

Also using is_numeric sanity check in place of is_integer.

See https://github.com/ezsystems/ezfind/pull/60
