### PR TITLE
Add Solr date format for use in templates for Solr date filters

### DIFF
--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -404,7 +404,7 @@ class ezfSolrDocumentFieldBase
      */
     static function convertTimestampToDate( $timestamp )
     {
-        return strftime( '%Y-%m-%dT%H:%M:%S.000Z', (int)$timestamp );
+        return strftime( '%Y-%m-%dT%H:%M:%SZ', (int)$timestamp );
     }
 
 

--- a/settings/datetime.ini.append.php
+++ b/settings/datetime.ini.append.php
@@ -2,7 +2,7 @@
 
 [ClassSettings]
 # Solr date format for date filters
-Formats[solr]=%Y-%m-%dT%H:%i:%s.000Z
+Formats[solr]=%Y-%m-%dT%H:%i:%sZ
 
 */
 ?>


### PR DESCRIPTION
Usage:

{$unix_timestamp|datetime( 'solr' )}

Generates a date formatted the same way as ezfSolrDocumentFieldBase::convertTimestampToDate
