### PR TITLE
Use proper eZ Find fetches in default admin2 and standard search templates

### DIFF
--- a/design/admin2/templates/content/search.tpl
+++ b/design/admin2/templates/content/search.tpl
@@ -2,13 +2,14 @@
 {let search=false()}
 {section show=$use_template_search}
     {set page_limit=10}
-    {set search=fetch(content,search,
-                      hash(text,$search_text,
-                           section_id,$search_section_id,
-                           subtree_array,$search_subtree_array,
-                           sort_by,array('modified',false()),
-                           offset,$view_parameters.offset,
-                           limit,$page_limit))}
+    {set search=fetch( 'ezfind', 'search',
+                        hash( 'query', $search_text,
+                              'section_id', $search_section_id,
+                              'subtree_array', $search_subtree_array,
+                              'sort_by', hash( 'modified', 'desc' ),
+                              'offset', $view_parameters.offset,
+                              'limit', $page_limit )
+                             )}
     {set search_result=$search['SearchResult']}
     {set search_count=$search['SearchCount']}
     {set stop_word_array=$search['StopWordArray']}

--- a/design/standard/templates/content/search.tpl
+++ b/design/standard/templates/content/search.tpl
@@ -1,13 +1,14 @@
 {def $search=false()}
 {if $use_template_search}
     {set $page_limit=10}
-    {set $search=fetch(content,search,
-                       hash(text,$search_text,
-                            section_id,$search_section_id,
-                            subtree_array,$search_subtree_array,
-                            sort_by,array('modified',false()),
-                            offset,$view_parameters.offset,
-                            limit,$page_limit))}
+    {set $search=fetch( 'ezfind', 'search',
+                        hash( 'query', $search_text,
+                              'section_id', $search_section_id,
+                              'subtree_array', $search_subtree_array,
+                              'sort_by', hash( 'modified', 'desc' ),
+                              'offset', $view_parameters.offset,
+                              'limit', $page_limit )
+                              )}
     {set $search_result=$search['SearchResult']}
     {set $search_count=$search['SearchCount']}
     {def $search_extras=$search['SearchExtras']}


### PR DESCRIPTION
Previously, sorting was broken because eZ Find sorting uses different syntax. Regardless, eZ Find search templates should be using eZ Find fetch functions.
