### PR TITLE
Fixed EZP-19673: search results contain link to hidden nodes

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -158,6 +158,7 @@ class ezfeZPSolrQueryBuilder
         $visibilityDefaultSetting = self::$SiteINI->variable( 'SiteAccessSettings', 'ShowHiddenNodes' );
         $visibilityDefault = ( $visibilityDefaultSetting === 'true' ) ? true : false;
         $ignoreVisibility = isset( $params['IgnoreVisibility'] )  ?  $params['IgnoreVisibility'] : $visibilityDefault;
+        $this->searchPluginInstance->postSearchProcessingData['ignore_visibility'] = $ignoreVisibility;
         $limitation = isset( $params['Limitation'] )  ?  $params['Limitation'] : null;
         $boostFunctions = isset( $params['BoostFunctions'] )  ?  $params['BoostFunctions'] : null;
         $forceElevation = isset( $params['ForceElevation'] )  ?  $params['ForceElevation'] : false;
@@ -451,7 +452,8 @@ class ezfeZPSolrQueryBuilder
                 eZSolr::getMetaFieldName( 'main_url_alias' ) . ' ' . eZSolr::getMetaFieldName( 'installation_url' ) . ' ' .
                 eZSolr::getMetaFieldName( 'id' ) . ' ' . eZSolr::getMetaFieldName( 'main_node_id' ) . ' ' .
                 eZSolr::getMetaFieldName( 'language_code' ) . ' ' . eZSolr::getMetaFieldName( 'name' ) .
-                ' score ' . eZSolr::getMetaFieldName( 'published' ) . ' ' . eZSolr::getMetaFieldName( 'path_string' ) . ' ' . implode( ' ', $extraFieldsToReturn );
+                ' score ' . eZSolr::getMetaFieldName( 'published' ) . ' ' . eZSolr::getMetaFieldName( 'path_string' ) . ' ' .
+                eZSolr::getMetaFieldName( 'is_invisible' ) . ' ' . implode( ' ', $extraFieldsToReturn );
 
         if ( ! $asObjects )
         {

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -345,16 +345,42 @@ class eZSolr implements ezpSearchEngine
             $docPathStrings,
             $subtreeLimitations
         );
+        $ignoreVisibility = eZContentObjectTreeNode::showInvisibleNodes();
+        if ( isset( $this->postSearchProcessingData['ignore_visibility'] ) )
+        {
+            $ignoreVisibility = $this->postSearchProcessingData['ignore_visibility'];
+        }
+
 
         // Intersect between $validSubtreeArray (search location filter) and $validSubtreeLimitations (user policy limitations)
         // indicates valid locations for $doc in current search query
-        // If this intersect is not empty, we take the first element to get the corresponding node ID
-        $validSubtrees = array_intersect( $validSubtreeArray, $validSubtreeLimitations );
+        // If this intersect is not empty, we take the first node id that
+        // matches the visibility requirement
+        $validSubtrees = array_flip(
+            array_intersect( $validSubtreeArray, $validSubtreeLimitations )
+        );
         if ( !empty( $validSubtrees ) )
         {
-            $validSubtree = array_shift( $validSubtrees );
-            $nodeArray = explode( '/', rtrim( $validSubtree, '/' ) );
-            return (int)array_pop( $nodeArray );
+            foreach ( $docPathStrings as $k => $path )
+            {
+                if ( isset( $validSubtrees[$path] ) )
+                {
+                    if (
+                        $ignoreVisibility ||
+                        !$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'is_invisible' )][$k]
+                    )
+                    {
+                        $nodeArray = explode( '/', rtrim( $path, '/' ) );
+                        return (int)array_pop( $nodeArray );
+                    }
+                }
+            }
+            eZDebug::writeError(
+                "Could not find a visible location for content " .
+                "#{$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'id' )]} " .
+                "that current user has read access on. The Solr index is probably outdated",
+                __METHOD__
+            );
         }
         else
         {
@@ -368,6 +394,17 @@ class eZSolr implements ezpSearchEngine
                     "Subtree limitations for user : " . print_r( $subtreeLimitations, true ),
                     __METHOD__
                 );
+            }
+            foreach ( $docPathStrings as $k => $path )
+            {
+                if (
+                    $ignoreVisibility ||
+                    !$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'is_invisible' )][$k]
+                )
+                {
+                    $nodeArray = explode( '/', rtrim( $path, '/' ) );
+                    return (int)array_pop( $nodeArray );
+                }
             }
         }
 


### PR DESCRIPTION
Bug: https://jira.ez.no/browse/EZP-19673
# Description

The ezfind search does not fully take into account the visibility of the locations of content. That's why, with content with several locations (some hidden, some not) the search results might contain links to hidden locations even if the siteaccess is configured to not show hidden nodes.
This patch makes `eZSolr::getNodeID()` a bit smarter so that it takes into account the visibility requirement to select a correct location.
# Tests

Manual tests
