### PR TITLE
Tweak "MM" config to return better results in english.

### DIFF
--- a/java/solr.multicore/eng-GB/conf/solrconfig.xml
+++ b/java/solr.multicore/eng-GB/conf/solrconfig.xml
@@ -1127,12 +1127,10 @@
       </str>
         <!-- mm explanation: for the values below:
            1, 2 keywords: at least one must match
-           from 3-5 keywords, at least 2-4 must match
-           from 6-7 keywords, at least 4-5 must match
-           above 7 keywords, 60% of them must match
+           above 3 keywords, 50% of them must match
         -->
         <str name="mm">
-          1&lt;1 2&lt;-1 5&lt;-2 7&lt;60%
+          1&lt;1 3&lt;50%
         </str>
         <int name="ps">100</int>
         <str name="q.alt">*:*</str>

--- a/java/solr/conf/solrconfig.xml
+++ b/java/solr/conf/solrconfig.xml
@@ -1143,12 +1143,10 @@
       </str>
         <!-- mm explanation: for the values below:
            1, 2 keywords: at least one must match
-           from 3-5 keywords, at least 2-4 must match
-           from 6-7 keywords, at least 4-5 must match
-           above 7 keywords, 60% of them must match
+           above 3 keywords, 50% of them must match
         -->
         <str name="mm">
-          1&lt;1 2&lt;-1 5&lt;-2 7&lt;60%
+          1&lt;1 3&lt;50%
         </str>
         <int name="ps">100</int>
         <str name="q.alt">*:*</str>


### PR DESCRIPTION
With the current MM config search strings such as `Cities of the Future` would not
match an article with the title `Asia-Pacific Cities of the Future`.
