### PR TITLE
issue_19976_19977

### DIFF
--- a/bin/scripts/rhel/solr
+++ b/bin/scripts/rhel/solr
@@ -157,9 +157,6 @@ case "$1" in
     echo " * Restarting $DESC ($NAME)"
     if d_status
     then
-      echo "   ...not running."
-      RETVAL=1
-    else
       if d_restart
       then
         echo " * ...done."
@@ -167,6 +164,9 @@ case "$1" in
         echo " * ...failed."
         RETVAL=1
       fi
+    else
+      echo "   ...not running."
+      RETVAL=1
     fi
     ;;
   reload)


### PR DESCRIPTION
- fixes script not working with centos 6.3
- adds support for /etc/sysconfig
- more checks for when path to ez is incorrect
- gives better output msg when the "stop" command actually does not stop anything (ie. says "failed")
