### PR TITLE
Fixed EZP-19993: indexing errors with attribute boosting using solr 3.6

### DIFF
--- a/java/solr/conf/schema.xml
+++ b/java/solr/conf/schema.xml
@@ -66,7 +66,7 @@
     -->
 
     <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="false"/>
 
     <!-- needed for the hardcoded meta fields -->
     <fieldType name="mstring" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>


### PR DESCRIPTION
As suggested by PB, disable omitNorms for string fieldType, fixes indexing with attribute boost on SOLR 3.6.1

Note that besides allowing index-time boosting, it will also enable length normalization, and (as per solr documentation) use slightly more memory.
