### PR TITLE
Fixed EZP-19992: eZ Find: {$node.highlight} is causing html/xml entities...

### DIFF
--- a/java/solr/conf/solrconfig.xml
+++ b/java/solr/conf/solrconfig.xml
@@ -1520,7 +1520,7 @@
 
       <!-- Configure the standard formatter -->
       <formatter name="html"
-                 default="true"
+                 default="false"
                  class="solr.highlight.HtmlFormatter">
         <lst name="defaults">
           <str name="hl.simple.pre"><![CDATA[<em>]]></str>


### PR DESCRIPTION
... to be shown.

Possible solution to prevent double-encoding of html entities, is to disable the html formatter by default for highlighted results.
