### PR TITLE
Added an init.d script for SUSE Linux Enterprise Server 11 SP1.

### DIFF
--- a/bin/scripts/sles11/solr
+++ b/bin/scripts/sles11/solr
@@ -1,0 +1,342 @@
+#!/bin/bash
+#
+#     SUSE system startup script for eZ Find / Solr
+#     Copyright (C) 2012 FA, NXC International SA
+#     Based on SLES11's template skeleton, which is
+#     Copyright (C) 1995--2005  Kurt Garloff, SUSE / Novell Inc.
+#
+#     This library is free software; you can redistribute it and/or modify it
+#     under the terms of the GNU Lesser General Public License as published by
+#     the Free Software Foundation; either version 2.1 of the License, or (at
+#     your option) any later version.
+#
+#     This library is distributed in the hope that it will be useful, but
+#     WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#     Lesser General Public License for more details.
+#
+#     You should have received a copy of the GNU Lesser General Public
+#     License along with this library; if not, write to the Free Software
+#     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
+#     USA.
+#
+# /etc/init.d/solr
+#   and its symbolic link
+# /(usr/)sbin/rcsolr
+#
+# System startup script for eZ Find / Solr
+#
+# LSB compatible service control script; see http://www.linuxbase.org/spec/
+#
+# Note: This script uses functions rc_XXX defined in /etc/rc.status on
+# UnitedLinux/SUSE/Novell based Linux distributions. If you want to base your
+# script on this script and ensure that it works on non UL based LSB
+# compliant Linux distributions, you either have to provide the rc.status
+# functions from UL or change the script to work without them.
+# Honestly, you'd be better off basing yours on the skeleton template.
+# See skeleton.compat for a template that works with other distros as well.
+#
+### BEGIN INIT INFO
+# Provides:          solr
+# Required-Start:    $local_fs $remote_fs
+# Should-Start:      $network $time
+# Required-Stop:     $local_fs $remote_fs
+# Should-Stop:       
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Solr daemon providing search services to eZ Find
+# Description:       Start Solr to provide search services for eZ Find.
+#	Solr is the backend indexer and search service used by eZ Find,
+#	which provides the search results on the eZ Publish site.
+### END INIT INFO
+#
+# Any extensions to the keywords given above should be preceeded by
+# X-VendorTag- (X-UnitedLinux- X-SuSE- for us) according to LSB.
+#
+# Notes on Required-Start/Should-Start:
+# * There are two different issues that are solved by Required-Start
+#    and Should-Start
+# (a) Hard dependencies: This is used by the runlevel editor to determine
+#     which services absolutely need to be started to make the start of
+#     this service make sense. Example: nfsserver should have
+#     Required-Start: $portmap
+#     Also, required services are started before the dependent ones.
+#     The runlevel editor will warn about such missing hard dependencies
+#     and suggest enabling. During system startup, you may expect an error,
+#     if the dependency is not fulfilled.
+# (b) Specifying the init script ordering, not real (hard) dependencies.
+#     This is needed by insserv to determine which service should be
+#     started first (and at a later stage what services can be started
+#     in parallel). The tag Should-Start: is used for this.
+#     It tells, that if a service is available, it should be started
+#     before. If not, never mind.
+# * When specifying hard dependencies or ordering requirements, you can
+#   use names of services (contents of their Provides: section)
+#   or pseudo names starting with a $. The following ones are available
+#   according to LSB (1.1):
+#	$local_fs		all local file systems are mounted
+#				(most services should need this!)
+#	$remote_fs		all remote file systems are mounted
+#				(note that /usr may be remote, so
+#				 many services should Require this!)
+#	$syslog			system logging facility up
+#	$network		low level networking (eth card, ...)
+#	$named			hostname resolution available
+#	$netdaemons		all network daemons are running
+#   The $netdaemons pseudo service has been removed in LSB 1.2.
+#   For now, we still offer it for backward compatibility.
+#   These are new (LSB 1.2):
+#	$time			the system time has been set correctly
+#	$portmap		SunRPC portmapping service available
+#   UnitedLinux extensions:
+#	$ALL			indicates that a script should be inserted
+#				at the end
+# * The services specified in the stop tags
+#   (Required-Stop/Should-Stop)
+#   specify which services need to be still running when this service
+#   is shut down. Often the entries there are just copies or a subset
+#   from the respective start tag.
+# * Should-Start/Stop are now part of LSB as of 2.0,
+#   formerly SUSE/Unitedlinux used X-UnitedLinux-Should-Start/-Stop.
+#   insserv does support both variants.
+# * X-UnitedLinux-Default-Enabled: yes/no is used at installation time
+#   (%fillup_and_insserv macro in %post of many RPMs) to specify whether
+#   a startup script should default to be enabled after installation.
+#   It's not used by insserv.
+#
+# Note on runlevels:
+# 0 - halt/poweroff 			6 - reboot
+# 1 - single user			2 - multiuser without network exported
+# 3 - multiuser w/ network (text mode)  5 - multiuser w/ network and X11 (xdm)
+#
+# Note on script names:
+# http://www.linuxbase.org/spec/refspecs/LSB_1.3.0/gLSB/gLSB/scrptnames.html
+# A registry has been set up to manage the init script namespace.
+# http://www.lanana.org/
+# Please use the names already registered or register one or use a
+# vendor prefix.
+
+
+# The location where solr is installed, usually .../ezp/extension/ezfind/java
+SOLR_HOME=..../extension/ezfind/java
+
+# The user to run solr as. Must be a user that can write to solr's data files.
+ASUSER=wwwrun
+
+# The file to log the output of solr to.
+# This can be quite a bit of output, so /dev/null is probably best.
+LOGFILE=/dev/null
+
+
+# Check for missing binaries (stale symlinks should not happen)
+# Note: Special treatment of stop for LSB conformance
+
+for JAVA in "$JAVA_HOME/bin/java" "/usr/bin/java" "/usr/local/bin/java"
+do
+	if [ -x "$JAVA" ]; then
+		break
+	fi
+done
+
+if ! [ -x "$JAVA" ]
+then
+	echo "Unable to locate java"
+	if [ "$1" = "stop" ]; then exit 0; else exit 5; fi
+fi
+
+SOLR_BIN="$JAVA"
+
+if [[ "$SOLR_HOME" == "..../extension/ezfind/java" ]]; then
+	echo "The init script for solr must be configured before use."
+	exit 1
+fi
+
+test -r "$SOLR_HOME/start.jar" || {
+	echo "solr not found in $SOLR_HOME";
+	if [ "$1" = "stop" ]; then exit 0; else exit 5; fi
+}
+
+PIDFILE=/var/run/solr.pid
+
+# Shell functions sourced from /etc/rc.status:
+#      rc_check         check and set local and overall rc status
+#      rc_status        check and set local and overall rc status
+#      rc_status -v     be verbose in local rc status and clear it afterwards
+#      rc_status -v -r  ditto and clear both the local and overall rc status
+#      rc_status -s     display "skipped" and exit with status 3
+#      rc_status -u     display "unused" and exit with status 3
+#      rc_failed        set local and overall rc status to failed
+#      rc_failed <num>  set local and overall rc status to <num>
+#      rc_reset         clear both the local and overall rc status
+#      rc_exit          exit appropriate to overall rc status
+#      rc_active        checks whether a service is activated by symlinks
+. /etc/rc.status
+
+# Reset status of this service
+rc_reset
+
+# Return values acc. to LSB for all commands but status:
+# 0	  - success
+# 1       - generic or unspecified error
+# 2       - invalid or excess argument(s)
+# 3       - unimplemented feature (e.g. "reload")
+# 4       - user had insufficient privileges
+# 5       - program is not installed
+# 6       - program is not configured
+# 7       - program is not running
+# 8--199  - reserved (8--99 LSB, 100--149 distrib, 150--199 appl)
+#
+# Note that starting an already running service, stopping
+# or restarting a not-running service as well as the restart
+# with force-reload (in case signaling is not supported) are
+# considered a success.
+
+solr_status() {
+	[ -e $PIDFILE ] || return 3
+	local PID=`cat $PIDFILE`
+	[[ "$PID" != "" ]] || return 4
+	[ -d /proc/$PID ] || return 1
+	[[ "`readlink /proc/$PID/cwd`" != "$SOLR_HOME" ]] && return 4
+	local CMD="`xargs -0 echo < /proc/$PID/cmdline`"
+	[[ "$CMD" != "$JAVA -jar start.jar" ]] && return 4
+	return 0
+}
+
+case "$1" in
+    start)
+	echo -n "Starting Solr "
+	## Start daemon with startproc(8). If this fails
+	## the return value is set appropriately by startproc.
+	if solr_status ; then
+		echo -n "(already running)"
+		rc_failed 0
+	else
+		if [ $? -eq 4 ]; then
+			echo "Warning: unknown state. Starting anyway." >&2
+		fi
+		# We start it via this bash script because it needs to handle
+		# the pid file and must be started from a specific directory.
+		/sbin/startproc -s -w -l $LOGFILE -p $PIDFILE \
+			/bin/bash $0 start-the-actual-daemon-now
+	fi
+
+	# Remember status and be verbose
+	rc_status -v
+	;;
+    start-the-actual-daemon-now)
+	if solr_status ; then
+		# Already running
+		exit 0
+	fi
+	if [ $UID -eq 0 ] && [[ "$2" != "with-the-user" ]] && \
+		[[ "$ASUSER" != "" ]] && [[ "$ASUSER" != "root" ]];
+	then
+		touch $PIDFILE
+		chown $ASUSER $PIDFILE
+		su -c "$0 start-the-actual-daemon-now with-the-user" $ASUSER
+		STATUS=$?
+		sleep 1
+		if [ -e $PIDFILE ] && ! solr_status ; then
+			echo "Solr failed to start, removing PID file." >&2
+			rm $PIDFILE
+		fi
+		exit $STATUS
+	fi
+	cd "$SOLR_HOME" || exit
+	$JAVA -jar start.jar &
+	PID=$!
+	echo $PID > $PIDFILE
+	sleep 2
+	exit
+	;;
+    stop)
+	echo -n "Shutting down Solr "
+	## Stop daemon with killproc(8) and if this fails
+	## killproc sets the return value according to LSB.
+
+	if solr_status ; then
+		/sbin/killproc -p $PIDFILE -TERM "$SOLR_BIN"
+	else
+		rc_failed 7
+	fi
+
+	# Remember status and be verbose
+	rc_status -v
+	;;
+    try-restart|condrestart)
+	## Do a restart only if the service was active before.
+	## Note: try-restart is now part of LSB (as of 1.9).
+	## RH has a similar command named condrestart.
+	if test "$1" = "condrestart"; then
+		echo "${attn} Use try-restart ${done}(LSB)${attn} rather than condrestart ${warn}(RH)${norm}"
+	fi
+	$0 status
+	if test $? = 0; then
+		$0 restart
+	else
+		rc_reset	# Not running is not a failure.
+	fi
+	# Remember status and be quiet
+	rc_status
+	;;
+    restart)
+	## Stop the service and regardless of whether it was
+	## running or not, start it again.
+	$0 stop
+	$0 start
+
+	# Remember status and be quiet
+	rc_status
+	;;
+    force-reload)
+	## Signal the daemon to reload its config. Most daemons
+	## do this on signal 1 (SIGHUP).
+	## If it does not support it, restart the service if it
+	## is running.
+
+	echo -n "Reload service Solr "
+	$0 try-restart
+	rc_status
+	;;
+    reload)
+	## Like force-reload, but if daemon does not support
+	## signaling, do nothing (!)
+
+	rc_failed 3
+	rc_status -v
+	;;
+    status)
+	echo -n "Checking for service Solr "
+	## Check status with checkproc(8), if process is running
+	## checkproc will return with exit status 0.
+
+	# Return value is slightly different for the status command:
+	# 0 - service up and running
+	# 1 - service dead, but /var/run/  pid  file exists
+	# 2 - service dead, but /var/lock/ lock file exists
+	# 3 - service not running (unused)
+	# 4 - service status unknown :-(
+	# 5--199 reserved (5--99 LSB, 100--149 distro, 150--199 appl.)
+	
+	# NOTE: checkproc returns LSB compliant status values.
+	#/sbin/checkproc -p $PIDFILE "$SOLR_BIN"
+	solr_status
+	
+	# NOTE: rc_status knows that we called this init script with
+	# "status" option and adapts its messages accordingly.
+	rc_status -v
+	;;
+    probe)
+	## Optional: Probe for the necessity of a reload, print out the
+	## argument to this init script which is required for a reload.
+	## Note: probe is not (yet) part of LSB (as of 1.9)
+
+	#test /etc/FOO/FOO.conf -nt /var/run/FOO.pid && echo reload
+	rc_failed 3
+	;;
+    *)
+	echo "Usage: $0 {start|stop|status|try-restart|restart|force-reload|reload}"
+	exit 1
+	;;
+esac
+rc_exit


### PR DESCRIPTION
This script is based on the template script the distro provides for the purpose of making new init scripts, and supports start, stop and status.
