### PR TITLE
Fix EZP-21096 : Index GM time, not local time

### DIFF
--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -404,7 +404,7 @@ class ezfSolrDocumentFieldBase
      */
     static function convertTimestampToDate( $timestamp )
     {
-        return strftime( '%Y-%m-%dT%H:%M:%SZ', (int)$timestamp );
+        return gmstrftime( '%Y-%m-%dT%H:%M:%SZ', (int)$timestamp );
     }
 
 


### PR DESCRIPTION
SolR times are decoded through strtotime which translates times to the current (PHP wise) timezone. Currently, the reverse shift is not done when indexing (local time is stored as GMT). 
