### PR TITLE
Fixed SearchServerURI condition fallback

### DIFF
--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -65,7 +65,7 @@ class eZSolrBase
         {
             $this->SearchServerURI = $baseURI;
         }
-        elseif ( isset( $iniSearchServerURI ) )
+        elseif ( $iniSearchServerURI )
         {
             $this->SearchServerURI = $this->SolrINI->variable( 'SolrBase', 'SearchServerURI' );
         }


### PR DESCRIPTION
The fall back is never executed, because the variable is defined five lines before.
