### PR TITLE
Fixed EZP-18195: $result.object is not correctly created

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1593,7 +1593,7 @@ class eZSolr implements ezpSearchEngine
                     }
 
                     $resultTree = new eZFindResultNode( $nodeRowList[$nodeID] );
-                    $resultTree->setContentObject( new eZContentObject( $nodeRowList[$nodeID] ) );
+                    $resultTree->setContentObject( eZContentObject::fetch( $nodeRowList[$nodeID]["contentobject_id"] ) );
                     $resultTree->setAttribute( 'is_local_installation', true );
                     // can_read permission must be checked as they could be out of sync in Solr, however, when called from template with:
                     // limitation, hash( 'accessWord', ... ) this check should not be performed as it has precedence.


### PR DESCRIPTION
The `eZContentObject` was created with a row retrieved from a call to `eZContentObjectTreeNode::fetch()`, obviously, an `eZContentObjectTreeNode` row cannot be used to create an `eZContentObject` in a straight way.
