### PR TITLE
added class check when deleteDocs in multishard setup

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -898,7 +898,8 @@ class eZSolr implements ezpSearchEngine
         {
             foreach ( $docs as $languageCode => $doc )
             {
-                $this->SolrLanguageShards[$languageCode]->deleteDocs( array( $doc ), false, $commit, $optimize );
+                if ($this->SolrLanguageShards[$languageCode] instanceof eZSolrBase )
+                    $this->SolrLanguageShards[$languageCode]->deleteDocs( array( $doc ), false, $commit, $optimize );
             }
         }
         else


### PR DESCRIPTION
In situation when there is more languages enabled in ezp but there are not all mapped to solr shards (multi-shard setup), object removal crashes. To prevent this we need to check if there is a shard mapped or not.
