### PR TITLE
Fix EZP-20804: updateindexsolr fails if timeout is lower than exec time

### DIFF
--- a/bin/php/updatesearchindexsolr.php
+++ b/bin/php/updatesearchindexsolr.php
@@ -592,7 +592,9 @@ class ezfUpdateSearchIndexSolr
         $dbImpl = $this->Options['db-driver'] ? $this->Options['db-driver'] : false;
         $showSQL = $this->Options['sql'] ? true : false;
 
-        $db = eZDB::instance();
+        // Forcing creation of new instance to avoid mysql wait_timeout to kill
+        // the connection before it's done
+        $db = eZDB::instance( false, false, true );
 
         if ( $dbHost or $dbName or $dbUser or $dbImpl )
         {


### PR DESCRIPTION
# Description

For users with a large subtree or those who changed mysql default timeout value (8 hours). It is impossible to reindex solr because the mysql connection times out and breaks the script.

In order to fix that we can recreate a new connection more often.
# Test

Manual test.
I started the script with the default timeout in verbose mode (it didn't break), at the end it displays the execution time. Then I setup the timeout to a value smaller than the execution time.
