### PR TITLE
Implement EZP-21380: 'highlighting' as a SearchExtras attribute

### DIFF
--- a/classes/ezfsearchresultinfo.php
+++ b/classes/ezfsearchresultinfo.php
@@ -74,7 +74,8 @@ class ezfSearchResultInfo
                       // spellcheck dictionary/index -- Solr php response writer "bug"
                       'spellcheck_collation',
                       'interestingTerms',
-                      'clusters'
+                      'clusters',
+                      'highlighting'
             );
     }
 
@@ -344,6 +345,17 @@ class ezfSearchResultInfo
                 if ( isset( $this->ResultArray['clusters'] ) )
                 {
                     return $this->ResultArray['clusters'];
+                }
+                else
+                {
+                    return false;
+                }
+            } break;
+            case 'highlighting':
+            {
+                if ( isset( $this->ResultArray['highlighting'] ) )
+                {
+                    return $this->ResultArray['highlighting'];
                 }
                 else
                 {


### PR DESCRIPTION
Allow retrieving 'highlighting' as an attribute from search result info ('SearchExtras').
