### PR TITLE
Implement EZP-21404: Allow excluding object owner/author from search

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -338,7 +338,10 @@ class ezfeZPSolrQueryBuilder
         if ( !$contentClassAttributeID )
         {
             $queryFields[] = eZSolr::getMetaFieldName( 'name' );
-            $queryFields[] = eZSolr::getMetaFieldName( 'owner_name' );
+            if ( !self::$FindINI->hasVariable( 'SearchFilters', 'ExcludeOwnerName' ) || self::$FindINI->variable( 'SearchFilters', 'ExcludeOwnerName' ) !== 'enabled' )
+            {
+                $queryFields[] = eZSolr::getMetaFieldName( 'owner_name' );
+            }
         }
 
 

--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -250,6 +250,9 @@ RawFilterList[]
 #Set to enabled if this is the case
 FilterHiddenFromDB=disabled
 
+# Option to exclude owner name from being used as a query field in searches (default: disabled )
+# ExcludeOwnerName=enabled
+
 [MoreLikeThis]
 #Experimental!!
 #fields to use for query term extraction: proper fields "native",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21404

Currently, the owner names of objects indexed by eZFind will be searchable.
For example, searching for 'Administrator' will display a lot of results on a fresh installation with demo content.

This PR adds an .ini setting to make it possible to exclude the owner_name meta field from searches.
