### PR TITLE
Fix EZP-21388: Object relation fails to be selected with eZ Find search

### DIFF
--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -41,7 +41,10 @@ class eZFindResultNode extends eZContentObjectTreeNode
     function eZFindResultNode( $rows = array() )
     {
         $this->eZContentObjectTreeNode( $rows );
-        $this->ContentObjectID = $rows['id'];
+        if ( isset( $rows['id'] ) )
+        {
+            $this->ContentObjectID = $rows['id'];
+        }
         $this->LocalAttributeValueList = array();
         $this->LocalAttributeNameList = array( 'is_local_installation',
                                                'name',


### PR DESCRIPTION
**eZContentObjectTreeNode** constructor doesn't assign **ContentObjectID** value unless it's already in cache. 
Therefore, **eZFindResultNode** was not properly prepared to be used in browse selection templates.

This approach might be a bit overkill, for the problem at hand, but the other solution I could foresee would implicate messing with eZContentObjectTreeNode itself. That could induce much more load on the system.

Manual tested
Note: _Since content objects tend to become cached through the testing steps, the patch seemed useless after a while. But after the test environment was restarted, the original bug was always present without the patch, and never reproducible with it applied_
