### PR TITLE
Added/Fixed PHPDocs

### DIFF
--- a/bin/php/updatesearchindexsolr.php
+++ b/bin/php/updatesearchindexsolr.php
@@ -210,6 +210,7 @@ class ezfUpdateSearchIndexSolr
             )
         )
         {
+            /** @var eZContentObjectTreeNode[] $subTree */
             foreach ( $subTree as $innerNode )
             {
                 $object = $innerNode->attribute( 'object' );
@@ -307,6 +308,7 @@ class ezfUpdateSearchIndexSolr
         $this->CLI->output( 'Number of objects to index: ' . $this->ObjectCount );
         $this->Script->resetIteration( $this->ObjectCount, 0 );
 
+        /** @var eZContentObjectTreeNode[] $topNodeArray */
         $topNodeArray = eZPersistentObject::fetchObjectList(
             eZContentObjectTreeNode::definition(),
             null,
@@ -414,7 +416,7 @@ class ezfUpdateSearchIndexSolr
     /**
      * Iterate index counter
      *
-     * @param int $count
+     * @param int|bool $count
      */
     protected function iterate( $count = false )
     {
@@ -436,9 +438,11 @@ class ezfUpdateSearchIndexSolr
     /**
      * Fork and execute
      *
-     * @param int $nodeid
+     * @param int $nodeID
      * @param int $offset
      * @param int $limit
+     *
+     * @return int
      */
     protected function forkAndExecute( $nodeID, $offset, $limit )
     {
@@ -534,6 +538,7 @@ class ezfUpdateSearchIndexSolr
      */
     protected function objectCount()
     {
+        /** @var eZContentObjectTreeNode[] $topNodeArray */
         $topNodeArray = eZPersistentObject::fetchObjectList(
             eZContentObjectTreeNode::definition(),
             null,
@@ -641,6 +646,7 @@ class ezfUpdateSearchIndexSolr
      * If $coreUrl is false, the default Solr Url from solr.ini is used
      *
      * @param mixed $coreUrl
+     *
      * @return bool
      */
     protected function isSolrRunning( $coreUrl = false )

--- a/classes/archive/filestorage/ezpfilearchive.php
+++ b/classes/archive/filestorage/ezpfilearchive.php
@@ -10,25 +10,27 @@
  */
 abstract class ezpFileArchive
 {
-
     /**
      * archiveFile method is common for all archive classes
      * @todo maybe define a global interface instead with this method?
+     *
      * @param string $path the filepath
+     * @param array $seeds
+     * @param string $prefix
      * @param string $realm a realm or other classifier, possibly to be used for partitioning
-     * @param array $keys an associative array of other values to avoid collisions if needed
-     *        standard elements are 'prefix', 'seeds'
-     *        the path should generally be used as a seed element as well
+     *
+     * @return array|bool
      */
     abstract protected function archiveFile( $path, $seeds, $prefix = null, $realm = null );
 
     /**
+     * @param string $path
+     * @param array $seeds
+     * @param string $prefix
+     * @param string $realm
      *
+     * @return string
      */
     abstract protected function getArchiveFileName( $path, $seeds, $prefix = null, $realm = null );
-
 }
-
-
-
 ?>

--- a/classes/archive/filestorage/ezpfilearchivefactory.php
+++ b/classes/archive/filestorage/ezpfilearchivefactory.php
@@ -11,11 +11,10 @@
 
 class ezpFileArchiveFactory
 {
-
     /**
-     *
      * @param string $method
-     * @param string $path
+     *
+     * @return bool|ezpFileArchiveFileSystem
      */
     public static function getFileArchiveHandler( $method = 'filesystem' )
     {
@@ -28,11 +27,6 @@ class ezpFileArchiveFactory
                 //break;
         }
     }
-
-
-
-
 }
-
 
 ?>

--- a/classes/archive/filestorage/ezpfilearchivefilesystem.php
+++ b/classes/archive/filestorage/ezpfilearchivefilesystem.php
@@ -11,12 +11,29 @@
 
 class ezpFileArchiveFileSystem extends ezpFileArchive
 {
-
+    /**
+     * @var string
+     */
     private $ArchiveDirName = 'archive';
+
+    /**
+     * @var string
+     */
     private $hashAlgorithm = 'md5';
+
+    /**
+     * @var string
+     */
     private $ArchiveDir;
+
+    /**
+     * @var int
+     */
     private $ArchiveDirLevels = 3;
 
+    /**
+     * Constructor
+     */
     public function  __construct()
     {
         $sys = eZSys::instance();
@@ -28,11 +45,8 @@ class ezpFileArchiveFileSystem extends ezpFileArchive
         }
     }
 
-
     public function archiveFile( $path, $seeds, $prefix = null, $realm = null )
     {
-
-
         $archiveFileName = $this->getArchiveFileName( $path, $seeds, $prefix, $realm );
         if ( eZFileHandler::copy( $path, $archiveFileName ) )
         {
@@ -42,10 +56,6 @@ class ezpFileArchiveFileSystem extends ezpFileArchive
         {
             return false;
         }
-
-
-
-
     }
 
     public function getArchiveFileName( $path, $seeds, $prefix = null, $realm = null )
@@ -74,7 +84,6 @@ class ezpFileArchiveFileSystem extends ezpFileArchive
 
         return $archiveFileName;
     }
-
 }
 
 ?>

--- a/classes/extendedattributefilters/ezfindgeodistextendedattributefilter.php
+++ b/classes/extendedattributefilters/ezfindgeodistextendedattributefilter.php
@@ -32,6 +32,7 @@ class eZFindGeoDistExtendedAttributeFilter implements eZFindExtendedAttributeFil
      * Modifies SolR query params according to filter parameters
      * @param array $queryParams
      * @param array $filterParams
+     *
      * @return array $queryParams
      */
     public function filterQueryParams( array $queryParams, array $filterParams )

--- a/classes/ezdatatypesolrstorage.php
+++ b/classes/ezdatatypesolrstorage.php
@@ -14,9 +14,10 @@ class ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array with keys 'content', 'has_rendered_content', 'rendered'
-     * required first level elements 'method', 'version_format', 'data_type_identifier', 'content'
-     * optional first level element is 'rendered' which should store (template) rendered xhtml snippets
+     *               required first level elements 'method', 'version_format', 'data_type_identifier', 'content'
+     *               optional first level element is 'rendered' which should store (template) rendered xhtml snippets
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )
     {

--- a/classes/ezfTemplateOperators.php
+++ b/classes/ezfTemplateOperators.php
@@ -14,16 +14,25 @@ class ezfTemplateOperators
 {
     const QUOTES_TO_ESCAPE = '"';
 
+    /**
+     * @return array
+     */
     public function operatorList()
     {
         return array( 'solr_escape', 'solr_quotes_escape' );
     }
 
+    /**
+     * @return bool
+     */
     public function namedParameterPerOperator()
     {
         return true;
     }
 
+    /**
+     * @return array
+     */
     public function namedParameterList()
     {
         return array(
@@ -38,6 +47,15 @@ class ezfTemplateOperators
         );
     }
 
+    /**
+     * @param eZTemplate $tpl
+     * @param string $operatorName
+     * @param array $operatorParameters
+     * @param string $rootNamespace
+     * @param string $currentNamespace
+     * @param mixed $operatorValue
+     * @param array $namedParameters
+     */
     public function modify( $tpl, $operatorName, $operatorParameters, $rootNamespace, $currentNamespace, &$operatorValue, $namedParameters )
     {
         switch ( $operatorName )
@@ -57,10 +75,12 @@ class ezfTemplateOperators
      * If there are double quotes inside $query, they will be escaped.
      * Edge quotes are ignored.
      *
-     * @param string $query
-     * @return string
      * @see http://lucene.apache.org/core/old_versioned_docs/versions/3_4_0/queryparsersyntax.html#Escaping%20Special%20Characters
      * @see http://issues.ez.no/18701
+     *
+     * @param string $query
+     *
+     * @return string
      */
     public function escapeQuery( $query )
     {
@@ -77,6 +97,7 @@ class ezfTemplateOperators
      *
      * @param string $query
      * @param bool $leaveEdgeQuotes If true, edge quotes surrounding $query will be ignored.
+     *
      * @return string
      */
     public function escapeQuotes( $query, $leaveEdgeQuotes = false )

--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -38,10 +38,9 @@ class ezfeZPSolrQueryBuilder
 {
     /**
      * Constructor
-     *
      * Sets variables for creating a new instance of ezfeZPSolrQueryBuilder
-     * @param Object $searchPluginInstance Search engine instance. Allows the query builder to
-     *        communicate with the caller ( eZSolr instance ).
+     *
+     * @param eZSolr $searchPluginInstance
      */
     function ezfeZPSolrQueryBuilder( $searchPluginInstance )
     {
@@ -49,13 +48,15 @@ class ezfeZPSolrQueryBuilder
     }
 
     /**
-     * @since eZ Find 2.0
      * build a multi field query, basically doing the same as a Lucene MultiField query
      * not always safe
+     *
+     * @since eZ Find 2.0
      * @param string $searchText
      * @param array $solrFields
-     * @param string $boostFields a hash array
+     * @param array $boostFields a hash array
      *
+     * @return string
      */
     public function buildMultiFieldQuery( $searchText, $solrFields = array(), $boostFields = array() )
     {
@@ -725,9 +726,11 @@ class ezfeZPSolrQueryBuilder
      * @since eZ Find 2.0
      *
      * More Like This similarity searches
-     * @param query
+     * @param string $queryType
+     * @param string $query
+     * @param array $params
      *
-     * @return
+     * @return array
      */
     public function buildMoreLikeThis( $queryType, $query, $params = array() )
     {
@@ -1077,9 +1080,11 @@ class ezfeZPSolrQueryBuilder
      * Identifies which boolean operator to use when building the filter string ( fq parameter in the final Solr raw request )
      * Removes the operator from the array, if existing.
      *
-     * @param array &$filter Filter array processed in self::getParamFilterQuery
-     * @returns string The boolean operator to use. Default to 'AND'
      * @see ezfeZPSolrQueryBuilder::getParamFilterQuery
+     *
+     * @param array &$filter Filter array processed in self::getParamFilterQuery
+     *
+     * @returns string The boolean operator to use. Default to 'AND'
      */
     protected function getBooleanOperatorFromFilter( &$filter )
     {
@@ -1559,6 +1564,7 @@ class ezfeZPSolrQueryBuilder
      *
      * @param array $limitation Override the limitation of the user. Same format as the return of eZUser::hasAccessTo()
      * @param boolean $ignoreVisibility Set to true for the visibility to be ignored
+     *
      * @return string Lucene/Solr query string which can be used as filter query for Solr
      */
     protected function policyLimitationFilterQuery( $limitation = null, $ignoreVisibility = null )
@@ -1765,11 +1771,11 @@ class ezfeZPSolrQueryBuilder
      * Get an array of class attribute identifiers based on either a class attribute
      * list, or a content classes list
      *
-     * @param array $classIDArray
+     * @param array|bool $classIDArray
      *        Classes to search in. Either an array of class ID, class identifiers,
      *        a class ID or a class identifier.
      *        Using numerical attribute/class identifiers for $classIDArray is more efficient.
-     * @param array $classAttributeID
+     * @param array|bool $classAttributeIDArray
      *        Class attributes to search in. Either an array of class attribute id,
      *        or a single class attribute. Literal identifiers are not allowed.
      * @param array $fieldTypeExcludeList
@@ -1862,6 +1868,11 @@ class ezfeZPSolrQueryBuilder
         return $fieldArray;
     }
 
+    /**
+     * @param array $parameterList
+     *
+     * @return array
+     */
     private function buildSearchResultClusterQuery( $parameterList = array() )
     {
         $result = array( 'clustering' => 'false');
@@ -1890,8 +1901,19 @@ class ezfeZPSolrQueryBuilder
     }
 
     /// Vars
+    /**
+     * @var eZINI
+     */
     static $FindINI;
+
+    /**
+     * @var eZINI
+     */
     static $SolrINI;
+
+    /**
+     * @var eZINI
+     */
     static $SiteINI;
 
     /**

--- a/classes/ezfindelevateconfiguration.php
+++ b/classes/ezfindelevateconfiguration.php
@@ -217,13 +217,14 @@ class eZFindElevateConfiguration extends eZPersistentObject
     /**
      * Retrieves the content objects elevated by a given query string, possibly per language.
      *
-     * @param mixed $searchQuery Can be a string containing the search_query to filter on.
+     * @param string|array $queryString Can be a string containing the search_query to filter on.
      *                           Can also be an array looking like the following, supporting fuzzy search optionnally.
      * <code>
      *    array( 'searchQuery' => ( string )  'foo bar',
      *           'fuzzy'       => ( boolean ) true      )
      * </code>
      *
+     * @param bool $groupByLanguage
      * @param string $languageCode if filtering on language-code is required
      * @param array $limit Associative array containing the 'offset' and 'limit' keys, with integers as values, framing the result set. Example :
      * <code>
@@ -232,7 +233,8 @@ class eZFindElevateConfiguration extends eZPersistentObject
      * </code>
      *
      * @param boolean $countOnly If only the count of matching results is needed
-     * @return mixed An array containing the content objects elevated by the query string, optionnally sorted by language code, null if error. If $countOnly is true,
+     *
+     * @return eZContentObject[]|array|int|null An array containing the content objects elevated by the query string, optionnally sorted by language code, null if error. If $countOnly is true,
      *               only the result count is returned.
      */
     public static function fetchObjectsForQueryString( $queryString, $groupByLanguage = true, $languageCode = null, $limit = null, $countOnly = false )
@@ -293,6 +295,8 @@ class eZFindElevateConfiguration extends eZPersistentObject
      * @param string $queryString Query string for which elevate configuration is added
      * @param int $objectID Content object for which the elevate configuration is added
      * @param string $languageCode Language code for which the elevate configuration is added. Defaults to 'all languages'
+     *
+     * @return eZFindElevateConfiguration|null
      */
     public static function add( $queryString, $objectID, $languageCode = self::WILDCARD )
     {
@@ -325,6 +329,8 @@ class eZFindElevateConfiguration extends eZPersistentObject
      * @param string $queryString Query string for which elevate configuration is removed
      * @param int $objectID Content object for which the elevate configuration is removed
      * @param string $languageCode Language code for which the elevate configuration is removed. Defaults to 'all languages'
+     *
+     * @return bool|void
      */
     public static function purge( $queryString = '' , $objectID = null, $languageCode = null )
     {
@@ -347,6 +353,8 @@ class eZFindElevateConfiguration extends eZPersistentObject
     /**
      * Synchronizes the elevate configuration stored in the DB
      * with the one actually used by Solr.
+     *
+     * @param eZSolrBase $shard
      *
      * @return boolean true if the whole operation passed, false otherwise.
      */
@@ -463,7 +471,8 @@ class eZFindElevateConfiguration extends eZPersistentObject
      * The requestHandler ( Solr extension ) will take care of reloading the configuration.
      *
      * @see $configurationXML
-     * @return void
+     * @param eZSolrBase $shard
+     * @throws Exception
      */
     protected static function pushConfigurationToSolr( $shard = null )
     {

--- a/classes/ezfindextendedattributefilterfactory.php
+++ b/classes/ezfindextendedattributefilterfactory.php
@@ -26,7 +26,9 @@ class eZFindExtendedAttributeFilterFactory
 
     /**
      * Get singleton instance for filter
+     *
      * @param string $filterID
+     *
      * @return eZFindExtendedAttributeFilterInterface|false
      */
     public static function getInstance( $filterID )

--- a/classes/ezfindextendedattributefilterinterface.php
+++ b/classes/ezfindextendedattributefilterinterface.php
@@ -12,8 +12,10 @@ interface eZFindExtendedAttributeFilterInterface
     /**
      * Modifies SolR query params according to filter parameters
      * The returned array is merged with global SolR query
+     *
      * @param array $queryParams
      * @param array $filterParams
+     *
      * @return array $queryParams
      */
     public function filterQueryParams( array $queryParams, array $filterParams );

--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -35,9 +35,11 @@
 
 class eZFindResultNode extends eZContentObjectTreeNode
 {
-    /*!
-     \reimp
-    */
+    /**
+     * Constructor
+     *
+     * @param array $rows
+     */
     function eZFindResultNode( $rows = array() )
     {
         $this->eZContentObjectTreeNode( $rows );
@@ -55,9 +57,6 @@ class eZFindResultNode extends eZContentObjectTreeNode
                                                'score_percent' );
     }
 
-    /*!
-     \reimp
-    */
     function attribute( $attr, $noFunction = false )
     {
         $retVal = null;
@@ -106,27 +105,18 @@ class eZFindResultNode extends eZContentObjectTreeNode
         return $retVal;
     }
 
-    /*!
-     \reimp
-    */
     function attributes()
     {
         return array_merge( $this->LocalAttributeNameList,
                             eZContentObjectTreeNode::attributes() );
     }
 
-    /*!
-     \reimp
-    */
     function hasAttribute( $attr )
     {
         return ( in_array( $attr, $this->LocalAttributeNameList ) ||
                  eZContentObjectTreeNode::hasAttribute( $attr ) );
     }
 
-    /*!
-     \reimp
-    */
     function setAttribute( $attr, $value )
     {
         switch( $attr )

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -35,9 +35,11 @@
 
 class eZFindResultObject extends eZContentObject
 {
-    /*!
-     \reimp
-    */
+    /**
+     * Constructor
+     *
+     * @param array $rows
+     */
     function eZFindResultObject( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
@@ -49,9 +51,6 @@ class eZFindResultObject extends eZContentObject
         }
     }
 
-    /*!
-     \reimp
-    */
     function attribute( $attr, $noFunction = false )
     {
         $retVal = null;
@@ -69,9 +68,6 @@ class eZFindResultObject extends eZContentObject
         return $retVal;
     }
 
-    /*!
-     \reimp
-    */
     function setAttribute( $attr, $value )
     {
         if ( in_array( $attr, $this->LocalAttributeNameList ) )
@@ -80,18 +76,12 @@ class eZFindResultObject extends eZContentObject
         }
     }
 
-    /*!
-     \reimp
-    */
     function attributes()
     {
         return array_merge( $this->LocalAttributeNameList,
                             eZContentObject::attributes() );
     }
 
-    /*!
-     \reimp
-    */
     function hasAttribute( $attr )
     {
         return ( in_array( $attr, $this->LocalAttributeNameList ) ||
@@ -100,7 +90,14 @@ class eZFindResultObject extends eZContentObject
 
 
     /// Object variables
+    /**
+     * @var array
+     */
     var $LocalAttributeValueList;
+
+    /**
+     * @var array
+     */
     var $LocalAttributeNameList;
 }
 

--- a/classes/ezfindservercallfunctions.php
+++ b/classes/ezfindservercallfunctions.php
@@ -9,9 +9,11 @@ class eZFindServerCallFunctions
     /**
      * Returns search results based on given params
      *
-     * @param mixed $args
-     * @return array
      * @deprecated Use ezjsc::search instead (in ezjscore)
+     *
+     * @param mixed $args
+     *
+     * @return array
      */
     public static function search( $args )
     {
@@ -104,6 +106,7 @@ class eZFindServerCallFunctions
      * Returns autocomplete suggestions for given params
      *
      * @param mixed $args
+     *
      * @return array
      */
     public static function autocomplete( $args )

--- a/classes/ezfmodulefunctioncollection.php
+++ b/classes/ezfmodulefunctioncollection.php
@@ -90,18 +90,32 @@ class ezfModuleFunctionCollection
     /**
      * Search function
      *
-     * @param string Query string
-     * @param int Offset
-     * @param int Limit
-     * @param array Facet definition
-     * @param array Filter parameters
-     * @param array Sort by parameters
-     * @param mixed Content class ID or list of content class IDs
-     * @param array list of subtree limitation node IDs
-     * @param boolean $enableElevation Controls whether elevation should be enabled or not
-     * @param boolean $forceElevation Controls whether elevation is forced. Applies when the srt criteria is NOT the default one ( 'score desc' ).
+     * @see ezfeZPSolrQueryBuilder::buildSearch()
      *
-     * @return array Search result
+     * @param string $query Query string
+     * @param int $offset Offset
+     * @param int $limit Limit
+     * @param array $facets Facet definition
+     * @param array $filters Filter parameters
+     * @param array $sortBy Sort by parameters
+     * @param int|int[] $classID Content class ID or list of content class IDs
+     * @param int $sectionID
+     * @param array $subtreeArray
+     * @param bool $ignoreVisibility
+     * @param array $limitation list of subtree limitation node IDs
+     * @param bool $asObjects
+     * @param bool $spellCheck
+     * @param array $boostFunctions
+     * @param string $queryHandler
+     * @param bool $enableElevation Controls whether elevation should be enabled or not
+     * @param bool $forceElevation Controls whether elevation is forced. Applies when the srt criteria is NOT the default one ( 'score desc' ).
+     * @param int $publishDate
+     * @param array $distributedSearch
+     * @param array $fieldsToReturn
+     * @param array $searchResultClustering
+     * @param array $extendedAttributeFilter
+     *
+     * @return array Search Result
      */
     public function search( $query, $offset = 0, $limit = 10, $facets = null,
                             $filters = null, $sortBy = null, $classID = null, $sectionID = null,
@@ -136,9 +150,9 @@ class ezfModuleFunctionCollection
     /**
      * rawSolrRequest function
      *
-     * @param base specifies the Solr server/shard to use
-     * @param request the base request
-     * @param parameters all parameters for the request
+     * @param string $baseURI specifies the Solr server/shard to use
+     * @param string $request the base request
+     * @param array $parameters all parameters for the request
      *
      * @return array result as a PHP array
      */
@@ -151,22 +165,22 @@ class ezfModuleFunctionCollection
 
     /**
      * moreLikeThis function
-     * @todo document the solrconfig.xml required setting for remote streaming to be true
-     *       if $queryType 'url' is to be used
+     *
+     * @todo document the solrconfig.xml required setting for remote streaming to be true if $queryType 'url' is to be used
      * @todo consider adding limitation and visibility parameters
      *
-     * @param string $queryType string ( 'nid' | 'oid' | 'text' | 'url' )
+     * @param string $queryType 'nid' | 'oid' | 'text' | 'url'
      * @param string $query value for QueryType
-     * @param int Offset
-     * @param int Limit
-     * @param array Facet definition
-     * @param array Filter parameters
-     * @param array Sort by parameters
-     * @param mixed Content class ID or list of content class IDs
-     * @param array list of subtree limitation node IDs
-     * @param boolean asObjects return regular eZPublish objects if true, stored Solr content if false
-     * @param string|null $queryInstallationID the eZ Find installation id to
-     *        use when looking for the reference document in Solr
+     * @param int $offset Offset
+     * @param int $limit Limit
+     * @param array $facets Facet definition
+     * @param array $filters Filter parameters
+     * @param array $sortBy Sort by parameters
+     * @param int|int[] $classID Content class ID or list of content class IDs
+     * @param int $sectionID
+     * @param array $subtreeArray list of subtree limitation node IDs
+     * @param bool $asObjects return regular eZPublish objects if true, stored Solr content if false
+     * @param string $queryInstallationID the eZ Find installation id to use when looking for the reference document in Solr
      *
      * @return array result as a PHP array
      */
@@ -256,9 +270,9 @@ class ezfModuleFunctionCollection
     /**
      * spellCheck function, see also the search integrated spell check
      *
-     * @param string contains the string/word
-     * @param parameters all parameters for the request
-     * @param realm the ini configured parameters grouped into a realm
+     * @param string $string contains the string/word
+     * @param array $parameters all parameters for the request
+     * @param string $realm the ini configured parameters grouped into a realm
      *
      * @return array result as a PHP array
      */
@@ -268,7 +282,9 @@ class ezfModuleFunctionCollection
         return false;
     }
 
-
+    /**
+     * @return array
+     */
     public function getDefaultSearchFacets()
     {
         $limit = 5;

--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -47,7 +47,7 @@ class ezfSolrDocumentFieldBase
      * Constructor. Use ezfSolrDocumentFieldBase::instance() to create new
      * object of ezfSolrDocumentFieldBase class.
      *
-     * @param eZContentObjectAttribute Instance of eZContentObjectAttribute
+     * @param eZContentObjectAttribute $attribute Instance of eZContentObjectAttribute
      */
     function __construct( eZContentObjectAttribute $attribute )
     {
@@ -186,9 +186,11 @@ class ezfSolrDocumentFieldBase
      * - textTight - Text, less filters are applied than for the text datatype.
      *
      * @see ezfSolrDocumentFieldName::$FieldTypeMap
-     * @param eZContentClassAttribute Instance of eZContentClassAttribute.
-     * @param $subAttribute string In case the type of a datatype's sub-attribute is requested,
-     *                             the subattribute's name is passed here.
+     *
+     * @param eZContentClassAttribute $classAttribute Instance of eZContentClassAttribute.
+     * @param $subAttribute string  In case the type of a datatype's sub-attribute is requested,
+     *                              the subattribute's name is passed here.
+     * @param string $context
      *
      * @return string Field type. Null if no field type is defined.
      */
@@ -266,8 +268,8 @@ class ezfSolrDocumentFieldBase
      * Get Field name. Classes extending ezfSolrDocumentFieldBase should extend this functions if
      * they provide custom field names.
      *
-     * @param eZContentClassAttribute Instance of eZContentClassAttribute.
-     * @param mixed Additional conditions for creating the field name. What
+     * @param eZContentClassAttribute $classAttribute Instance of eZContentClassAttribute.
+     * @param mixed $subattribute Additional conditions for creating the field name. What
      *              this value may be depends on the Datatype used for the
      *              eZContentClassAttribute. Default value: null.
      *
@@ -285,6 +287,7 @@ class ezfSolrDocumentFieldBase
      *
      * @param eZContentClassAttribute $classAttribute Instance of eZContentClassAttribute.
      * @param mixed $subAttribute Typically the 'subattribute' name
+     * @param string $context
      *
      * @return string Fully qualified Solr field name.
      */
@@ -314,7 +317,7 @@ class ezfSolrDocumentFieldBase
      * To override the standard class ezfSolrDocumentFieldBase, specify in the configuration
      * files which sub-class which should be used.
      *
-     * @param eZContentObjectAttribute Instance of eZContentObjectAttribute.
+     * @param eZContentObjectAttribute $objectAttribute Instance of eZContentObjectAttribute.
      *
      * @return ezfSolrDocumentFieldBase Instance of ezfSolrDocumentFieldBase.
      */
@@ -345,10 +348,10 @@ class ezfSolrDocumentFieldBase
      * Preprocess value to make sure it complies to the
      * requirements Solr has to the different field types.
      *
-     * @param mixed Value
-     * @param string Fielt type
+     * @param mixed $value
+     * @param string $fieldType
      *
-     * @return moxed Processed value
+     * @return mixed Processed value
      */
     static function preProcessValue( $value, $fieldType )
     {
@@ -389,7 +392,7 @@ class ezfSolrDocumentFieldBase
      * Convert timestamp to Solr date
      * See also: http://www.w3.org/TR/xmlschema-2/#dateTime
      *
-     * @param int Timestamp
+     * @param int $timestamp
      *
      * @return string Solr datetime
      */
@@ -445,6 +448,8 @@ class ezfSolrDocumentFieldBase
      * It is used in the search plugin eZSolr.
      *
      * @param string $baseName
+     * @param string $context
+     *
      * @return string
      *
      * @example
@@ -464,6 +469,7 @@ class ezfSolrDocumentFieldBase
      *
      * @param string $baseName
      * @param eZContentClassAttribute $classAttribute
+     *
      * @return string
      *
      * @example
@@ -501,9 +507,19 @@ class ezfSolrDocumentFieldBase
             return false;
     }
 
-    /// Vars
+    /**
+     * @var eZContentObjectAttribute
+     */
     public $ContentObjectAttribute;
+
+    /**
+     * @var eZINI
+     */
     static $FindINI;
+
+    /**
+     * @var ezfSolrDocumentFieldName
+     */
     static $DocumentFieldName;
 
     /**

--- a/classes/ezfsolrdocumentfieldgmaplocation.php
+++ b/classes/ezfsolrdocumentfieldgmaplocation.php
@@ -11,12 +11,14 @@
 
 class ezfSolrDocumentFieldGmapLocation extends ezfSolrDocumentFieldBase
 {
+    /**
+     * @var array
+     */
     public static $subattributesDefinition = array( self::DEFAULT_SUBATTRIBUTE => 'text',
                                                     'coordinates' => 'geopoint',
                                                     'geohash' => 'geohash',
                                                     'latitude' => 'float',
                                                     'longitude' => 'float' );
-
 
     const DEFAULT_SUBATTRIBUTE = 'address';
 
@@ -24,7 +26,6 @@ class ezfSolrDocumentFieldGmapLocation extends ezfSolrDocumentFieldBase
     {
         parent::__construct( $attribute );
     }
-
 
     public function getData()
     {
@@ -93,6 +94,7 @@ class ezfSolrDocumentFieldGmapLocation extends ezfSolrDocumentFieldBase
         }
         return $subfields;
     }
+
     static function getClassAttributeType( eZContentClassAttribute $classAttribute, $subAttribute = null, $context = 'search' )
     {
         if ( $subAttribute and

--- a/classes/ezfsolrdocumentfieldobjectrelation.php
+++ b/classes/ezfsolrdocumentfieldobjectrelation.php
@@ -146,8 +146,10 @@ class ezfSolrDocumentFieldObjectRelation extends ezfSolrDocumentFieldBase
      * Identifies, based on the existing object relations, the type of the subattribute.
      *
      * @param eZContentClassAttribute $classAttribute The ezobjectrelation/ezobjectrelationlist attribute
-     * @param $subAttribute The subattribute's name
-     * @return string The type of the subattribute, false otherwise.
+     * @param string $subAttribute The subattribute's name
+     * @param string $context
+     *
+     * @return string|bool The type of the subattribute, false otherwise.
      */
     protected static function getTypeForSubattribute( eZContentClassAttribute $classAttribute, $subAttribute, $context = 'search'  )
     {

--- a/classes/ezfsolrdocumentfieldxml.php
+++ b/classes/ezfsolrdocumentfieldxml.php
@@ -37,9 +37,9 @@
 class ezfSolrDocumentFieldXML extends ezfSolrDocumentFieldBase
 {
     /**
+     * @param string $text
      *
-     * @param text $text
-     * @return text
+     * @return string
      *
      * instead of walking thorugh the dom tree, strip all xml/html like
      * this is more brute force, but helps in the case of html literal blocks

--- a/classes/ezfsolrstorage.php
+++ b/classes/ezfsolrstorage.php
@@ -17,17 +17,11 @@
 
 class ezfSolrStorage
 {
-
-    /**
-     *
-     */
     const STORAGE_ATTR_FIELD_PREFIX = 'as_';
     const STORAGE_ATTR_FIELD_SUFFIX = '_bst';
     const CONTENT_METHOD_TOSTRING = 'to_string';
     const CONTENT_METHOD_CUSTOM_HANDLER = 'custom_handler';
     const STORAGE_VERSION_FORMAT = '1';
-
-    /* var $handler; */
 
     function  __construct( )
     {
@@ -36,9 +30,9 @@ class ezfSolrStorage
 
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
+     *
      * @return array for further processing
      */
-
     public static function getAttributeData ( eZContentObjectAttribute $contentObjectAttribute )
     {
         $dataTypeIdentifier = $contentObjectAttribute->attribute( 'data_type_string' );
@@ -71,15 +65,20 @@ class ezfSolrStorage
         }
     }
 
+    /**
+     * @param $attributeData
+     *
+     * @return string
+     */
     public static function serializeData ( $attributeData )
     {
-            return base64_encode( json_encode( $attributeData ) );
+        return base64_encode( json_encode( $attributeData ) );
     }
 
     /**
+     * @param string $storageString
      *
-     * @param string $jsonString
-     * @return mixed
+     * @return array
      */
     public static function unserializeData ( $storageString )
     {
@@ -90,8 +89,8 @@ class ezfSolrStorage
     }
 
     /**
-     *
      * @param string $fieldNameBase
+     *
      * @return string Solr field name
      */
     public static function getSolrStorageFieldName( $fieldNameBase )

--- a/classes/ezfsolrutils.php
+++ b/classes/ezfsolrutils.php
@@ -15,20 +15,7 @@
  */
 class ezfSolrUtils
 {
-
     /**
-     *
-     */
-
-
-    /*function  __construct( )
-    {
-
-    }*/
-
-
-    /**
-     *
      * @param eZSolrBase $fromCore
      * @param eZSolrBase $toCore
      * @param string $keyField
@@ -40,6 +27,7 @@ class ezfSolrUtils
      * @param boolean $commit
      * @param boolean $optimize
      * @param int $commitWithin
+     *
      * @return boolean success (true |  false)
      */
     public static function copyDocument ( eZSolrBase $fromCore, eZSolrBase $toCore, $keyField, $docID, $params = array(), $commit = false, $optimize = false, $commitWithin = 0 )
@@ -88,7 +76,6 @@ class ezfSolrUtils
     }
 
     /**
-     *
      * @param eZSolrBase $fromCore
      * @param eZSolrBase $toCore
      * @param string $keyField
@@ -100,6 +87,7 @@ class ezfSolrUtils
      * @param boolean $commit
      * @param boolean $optimize
      * @param int $commitWithin
+     *
      * @return boolean success
      */
     public static function moveDocument ( eZSolrBase $fromCore, eZSolrBase $toCore, $keyField, $docID, $params = array(), $commit = false, $optimize = false, $commitWithin = 0 )
@@ -116,18 +104,17 @@ class ezfSolrUtils
     }
 
     /**
-     *
      * @param eZSolrBase $fromCore
      * @param eZSolrBase $toCore
-     * @param <type> $keyField
-     * @param <type> $filterQuery
-     * @param <type> $params hash array with fields to modify or add, fields to suppress
+     * @param string $keyField
+     * @param string $filterQuery
+     * @param array $params hash array with fields to modify or add, fields to suppress
      *      hash keys: 'modify_fields' (hash array key->value),
      *                 'suppress_fields' (array of strings),
      *                 'add_fields' (hash array key->value)
-     * @param <type> $commit
-     * @param <type> $optimize
-     * @param <type> $commitWithin
+     * @param bool $commit
+     * @param bool $optimize
+     * @param int $commitWithin
      */
     public static function copyDocumentsByQuery ( eZSolrBase $fromCore, eZSolrBase $toCore, $keyField, $filterQuery, $params = array(), $commit = false, $optimize = false, $commitWithin = 0 )
     {
@@ -148,15 +135,15 @@ class ezfSolrUtils
      *
      * @param eZSolrBase $fromCore
      * @param eZSolrBase $toCore
-     * @param <type> $keyField
-     * @param <type> $filterQuery
-     * @param <type> $params hash array with fields to modify or add, fields to suppress
+     * @param string $keyField
+     * @param string $filterQuery
+     * @param array $params hash array with fields to modify or add, fields to suppress
      *      hash keys: 'modify_fields' (hash array key->value),
      *                 'suppress_fields' (array of strings),
      *                 'add_fields' (hash array key->value)
-     * @param <type> $commit
-     * @param <type> $optimize
-     * @param <type> $commitWithin
+     * @param bool $commit
+     * @param bool $optimize
+     * @param int $commitWithin
      */
     public static function moveDocumentsByQuery ( eZSolrBase $fromCore, eZSolrBase $toCore, $keyField, $filterQuery, $params = array(), $commit = false, $optimize = false, $commitWithin = 0 )
     {
@@ -174,12 +161,12 @@ class ezfSolrUtils
     }
 
     /**
-     *
      * @param eZSolrBase $solrCore the Solr instance to use
      * @param array $fields a hash array in teh form fieldname => fieldvalue (single scalar or array for multivalued fields)
      * @param boolean $commit do a commit or not
      * @param boolean $optimize do an optimize or not, usually false as this can be very CPU intensive
      * @param int $commitWithin optional commitWithin commit window expressed in milliseconds
+     *
      * @return boolean success or failure
      */
     public static function addDocument (eZSolrBase $solrCore, $fields = array(), $commit = false, $optimize = false, $commitWithin = 0 )

--- a/classes/ezsolrdoc.php
+++ b/classes/ezsolrdoc.php
@@ -97,6 +97,10 @@ class eZSolrDoc
         $this->Doc[$name]['boost'] = $boost;
     }
 
+    /**
+     * @param string $name
+     * @param int|float $boost
+     */
     public function setFieldBoost ($name, $boost)
     {
         if ( $boost !== null && is_numeric($boost) && array_key_exists($name, $this->Doc))

--- a/classes/indexplugins/ezfindexparentname.php
+++ b/classes/indexplugins/ezfindexparentname.php
@@ -19,16 +19,19 @@ class ezfIndexParentName implements ezfIndexPlugin
      * The modify method gets the current content object AND the list of
      * Solr Docs (for each available language version).
      *
-     *
-     * @param eZContentObject $contentObect
-     * @param array $docList
+     * @param eZContentObject $contentObject
+     * @param eZSolrDoc[] $docList
+     * @internal param \eZContentObject $contentObect
      */
     public function modify( eZContentObject $contentObject, &$docList )
     {
+        /** @var eZContentObjectTreeNode $contentNode */
         $contentNode = $contentObject->attribute( 'main_node' );
+        /** @var eZContentObjectTreeNode $parentNode */
         $parentNode = $contentNode->attribute( 'parent' );
         if ( $parentNode instanceof eZContentObjectTreeNode )
         {
+            /** @var eZContentObject $parentObject */
             $parentObject       = $parentNode->attribute( 'object' );
             $parentVersion      = $parentObject->currentVersion();
             if( $parentVersion === false )

--- a/classes/solrstorage/ezauthorsolrstorage.php
+++ b/classes/solrstorage/ezauthorsolrstorage.php
@@ -14,6 +14,7 @@ class ezauthorSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezbinaryfilesolrstorage.php
+++ b/classes/solrstorage/ezbinaryfilesolrstorage.php
@@ -15,7 +15,8 @@ class ezbinaryfileSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
-     * @return json encoded string for further processing
+     *
+     * @return string json encoded string for further processing
      * required first level elements 'method', 'version_format', 'data_type_identifier', 'content'
      * optional first level element is 'rendered' which should store (template) rendered xhtml snippets
      */

--- a/classes/solrstorage/ezdatetimesolrstorage.php
+++ b/classes/solrstorage/ezdatetimesolrstorage.php
@@ -14,6 +14,7 @@ class ezdatetimeSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezenumsolrstorage.php
+++ b/classes/solrstorage/ezenumsolrstorage.php
@@ -14,6 +14,7 @@ class ezenumSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezkeywordsolrstorage.php
+++ b/classes/solrstorage/ezkeywordsolrstorage.php
@@ -14,6 +14,7 @@ class ezkeywordSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezmatrixsolrstorage.php
+++ b/classes/solrstorage/ezmatrixsolrstorage.php
@@ -17,6 +17,7 @@ class ezmatrixSolrStorage extends ezdatatypeSolrStorage
      *
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezmultioptionsolrstorage.php
+++ b/classes/solrstorage/ezmultioptionsolrstorage.php
@@ -14,6 +14,7 @@ class ezmultioptionSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezobjectrelationlistsolrstorage.php
+++ b/classes/solrstorage/ezobjectrelationlistsolrstorage.php
@@ -14,6 +14,7 @@ class ezobjectrelationlistSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezoptionsolrstorage.php
+++ b/classes/solrstorage/ezoptionsolrstorage.php
@@ -14,6 +14,7 @@ class ezoptionSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezpricesolrstorage.php
+++ b/classes/solrstorage/ezpricesolrstorage.php
@@ -14,6 +14,7 @@ class ezpriceSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezproductcategorysolrstorage.php
+++ b/classes/solrstorage/ezproductcategorysolrstorage.php
@@ -14,6 +14,7 @@ class ezproductcategorySolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezrangeoptionsolrstorage.php
+++ b/classes/solrstorage/ezrangeoptionsolrstorage.php
@@ -14,6 +14,7 @@ class ezrangeoptionSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezselectionsolrstorage.php
+++ b/classes/solrstorage/ezselectionsolrstorage.php
@@ -14,6 +14,7 @@ class ezselectionSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezurlsolrstorage.php
+++ b/classes/solrstorage/ezurlsolrstorage.php
@@ -14,6 +14,7 @@ class ezurlSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezusersolrstorage.php
+++ b/classes/solrstorage/ezusersolrstorage.php
@@ -14,6 +14,7 @@ class ezuserSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
+     *
      * @return array
      */
     public static function getAttributeContent( eZContentObjectAttribute $contentObjectAttribute, eZContentClassAttribute $contentClassAttribute )

--- a/classes/solrstorage/ezxmltextsolrstorage.php
+++ b/classes/solrstorage/ezxmltextsolrstorage.php
@@ -15,7 +15,8 @@ class ezxmltextSolrStorage extends ezdatatypeSolrStorage
     /**
      * @param eZContentObjectAttribute $contentObjectAttribute the attribute to serialize
      * @param eZContentClassAttribute $contentClassAttribute the content class of the attribute to serialize
-     * @return json encoded string for further processing
+     *
+     * @return string json encoded string for further processing
      * required first level elements 'method', 'version_format', 'data_type_identifier', 'content'
      * optional first level element is 'rendered' which should store (template) rendered xhtml snippets
      */

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -82,6 +82,7 @@ class eZSolr implements ezpSearchEngine
      * and fill the structure described below.
      *
      * @param eZContentObject $object
+     *
      * @return array
      * <code>
      *    array(
@@ -128,8 +129,8 @@ class eZSolr implements ezpSearchEngine
     /**
      * Get meta attribute Solr document field type
      *
-     * @param  string name Meta attribute name
-     * @param  string context search, facet, filter, sort
+     * @param string $name Meta attribute name
+     * @param string $context search, facet, filter, sort
      *
      * @return string Solr document field type. Null if meta attribute type does not exists.
      */
@@ -179,7 +180,7 @@ class eZSolr implements ezpSearchEngine
      *
      * @param string $baseName Base field name.
      * @param boolean $includingClassID conditions the structure of the answer. See return value explanation.
-     * @param $context is introduced in ez find 2.2 to allow for more optimal sorting, faceting, filtering
+     * @param string $context is introduced in ez find 2.2 to allow for more optimal sorting, faceting, filtering
      *
      * @return mixed Internal base name. Returns null if no valid base name was provided.
      *               If $includingClassID is true, an associative array will be returned, as shown below :
@@ -257,7 +258,8 @@ class eZSolr implements ezpSearchEngine
     /**
      * Check if eZSolr has meta attribute type.
      *
-     * @param string Meta attribute name
+     * @param string $name Meta attribute name
+     * @param string $context
      *
      * @return string Solr document field type
      */
@@ -271,7 +273,8 @@ class eZSolr implements ezpSearchEngine
      *
      * Get meta attribute field name
      *
-     * @param string Meta attribute field name ( base )
+     * @param string $baseName Meta attribute field name ( base )
+     * @param string $context
      *
      * @return string Solr doc field name
      */
@@ -310,6 +313,7 @@ class eZSolr implements ezpSearchEngine
      * depending on whether a subtree filter was applied or not.
      *
      * @param array $doc The search result, directly received from Solr.
+     *
      * @return string The URL Alias corresponding the the search result
      */
     protected function getUrlAlias( $doc )
@@ -330,6 +334,7 @@ class eZSolr implements ezpSearchEngine
      * so that valid locations must comply subtree filters (if any) AND subtree/node policy limitations (if any)
      *
      * @param array $doc The search result, directly received from Solr.
+     *
      * @return int The NodeID corresponding the search result
      */
     protected function getNodeID( $doc )
@@ -427,6 +432,7 @@ class eZSolr implements ezpSearchEngine
      *
      * @param array $pathStrings Array of path strings (i.e. locations for a content object)
      * @param array $subtreeLimitations Array of NodeIds that are considered valid (i.e. policy limitations or location filters)
+     *
      * @return array
      */
     private function getValidPathStringsByLimitation( array $pathStrings, array $subtreeLimitations )
@@ -461,7 +467,8 @@ class eZSolr implements ezpSearchEngine
      * @param eZContentObject $contentObject Object to add to search engine
      * @param bool $commit Whether to commit after adding the object.
      *        If set, run optimize() as well every 1000nd time this function is run.
-     * @param $commitWithin Commit within delay (see Solr documentation)
+     * @param int $commitWithin Commit within delay (see Solr documentation)
+     *
      * @return bool True if the operation succeed.
      */
     function addObject( $contentObject, $commit = true, $commitWithin = 0 )
@@ -763,8 +770,11 @@ class eZSolr implements ezpSearchEngine
     /**
      * Add instance of ezfSolrDocumentFieldBase to Solr document.
      *
-     * @param ezfSolrDocumentFieldBase Instance of ezfSolrDocumentFieldBase
-     * @param eZSolrDoc Solr document
+     * @param ezfSolrDocumentFieldBase $fieldBase Instance of ezfSolrDocumentFieldBase
+     * @param eZSolrDoc $doc Solr document
+     * @param bool $boost
+     *
+     * @return bool
      */
     function addFieldBaseToDoc( ezfSolrDocumentFieldBase $fieldBase, eZSolrDoc $doc, $boost = false )
     {
@@ -844,6 +854,7 @@ class eZSolr implements ezpSearchEngine
      * @deprecated Since 5.0, use removeObjectById()
      * @param eZContentObject $contentObject the content object to remove
      * @param bool $commit Whether to commit after removing the object
+     *
      * @return bool True if the operation succeed.
      */
     function removeObject( $contentObject, $commit = null )
@@ -857,6 +868,7 @@ class eZSolr implements ezpSearchEngine
      * @since 5.0
      * @param int $contentObjectId The content object to remove by id
      * @param bool $commit Whether to commit after removing the object
+     *
      * @return bool True if the operation succeed.
      */
     public function removeObjectById( $contentObjectId, $commit = null )
@@ -911,10 +923,11 @@ class eZSolr implements ezpSearchEngine
      * Search on the Solr search server
      * @todo: add functionality not to call the DB to recreate objects : $asObjects == false
      *
-     * @param string search term
-     * @param array parameters. @see ezfeZPSolrQueryBuilder::buildSearch()
      * @see ezfeZPSolrQueryBuilder::buildSearch()
-     * @param array search types. Reserved.
+     *
+     * @param string $searchText
+     * @param array $params parameters.
+     * @param array $searchTypes Reserved.
      *
      * @return array List of eZFindResultNode objects.
      */
@@ -1131,9 +1144,13 @@ class eZSolr implements ezpSearchEngine
      * use spellcheck option in search for spellchecking search results
      *
      * @package unfinished
+     * @param string $string
+     * @param bool $onlyMorePopular
+     * @param int $suggestionCount
+     * @param float $accuracy
+     *
      * @return array Solr result set.
      * @todo: configure different spell check handlers and handle multicore configs (need a parameter for it)
-     *
      */
     function spellCheck ( $string, $onlyMorePopular = false, $suggestionCount = 1, $accuracy = 0.5 )
     {
@@ -1179,6 +1196,7 @@ class eZSolr implements ezpSearchEngine
      *
      * @param eZContentObject|int $contentObject The content object OR content object Id
      * @param string $languageCode
+     *
      * @return string guid
      */
     function guid( $contentObject, $languageCode = '' )
@@ -1191,9 +1209,13 @@ class eZSolr implements ezpSearchEngine
 
     /**
      * Clean up search index for current installation.
+     *
+     * @param bool $allInstallations
+     * @param bool $optimize
+     *
      * @return bool true if cleanup was successful
      * @todo:  handle multicore configs (need a parameter for it) for return values
-    **/
+     */
     function cleanup( $allInstallations = false, $optimize = false )
     {
         if ( $allInstallations === true )
@@ -1307,11 +1329,15 @@ class eZSolr implements ezpSearchEngine
      * Called when a new section is assigned to an object, trough a node.
      * Simply re-index for now
      *
+     * @see eZSearch::updateNodeSection()
+     *
      * @todo: defer to cron if there are children involved and re-index these too
      * @todo when Solr supports it: update fields only
      *
+     * @param int $nodeID
+     * @param int $sectionID
+     *
      * @return void
-     * @see eZSearch::updateNodeSection()
      */
     public function updateNodeSection( $nodeID, $sectionID )
     {
@@ -1322,10 +1348,12 @@ class eZSolr implements ezpSearchEngine
     /**
      * Update the section in the search engine
      *
-     * @param array $objectID
-     * @param int $sectionID
-     * @return void
      * @see eZSearch::updateObjectsSection()
+     *
+     * @param array $objectIDs
+     * @param int $sectionID
+     *
+     * @return void
      */
     public function updateObjectsSection( array $objectIDs, $sectionID )
     {
@@ -1345,12 +1373,14 @@ class eZSolr implements ezpSearchEngine
      * Will re-index content identified by $nodeID.
      * If the node has children, they will be also re-indexed, but this action is deferred to ezfindexsubtree cronjob.
      *
+     * @see eZSearch::updateNodeVisibility()
+     *
      * @todo when Solr supports it: update fields only
      *
      * @param $nodeID
      * @param $action
+     *
      * @return void
-     * @see eZSearch::updateNodeVisibility()
      */
     public function updateNodeVisibility( $nodeID, $action )
     {
@@ -1373,14 +1403,14 @@ class eZSolr implements ezpSearchEngine
      * Called when a node assignement is added to an object.
      * Simply re-index for now.
      *
+     * @see eZSearch::addNodeAssignment()
+     *
      * @todo: defer to cron if there are children involved and re-index these too
      * @todo when Solr supports it: update fields only
      *
      * @param $mainNodeID
      * @param $objectID
      * @param $nodeAssignmentIDList
-     * @return unknown_type
-     * @see eZSearch::addNodeAssignment()
      */
     public function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList )
     {
@@ -1394,10 +1424,11 @@ class eZSolr implements ezpSearchEngine
      * @todo: defer to cron if there are children involved and re-index these too
      * @todo when Solr supports it: update fields only
      *
-     * @param $mainNodeID
-     * @param $objectID
-     * @param $nodeAssignmentIDList
-     * @return unknown_type
+     * @param int $mainNodeID
+     * @param int $newMainNodeID
+     * @param int $objectID
+     * @param array $nodeAssigmentIDList
+     * @return void
      * @see eZSearch::removeNodeAssignment()
      */
     public function removeNodeAssignment( $mainNodeID, $newMainNodeID, $objectID, $nodeAssigmentIDList )
@@ -1415,7 +1446,6 @@ class eZSolr implements ezpSearchEngine
      * @param $nodeID
      * @param $selectedNodeID
      * @param $nodeIdList
-     * @return void
      */
     public function swapNode( $nodeID, $selectedNodeID, $nodeIdList = array() )
     {


### PR DESCRIPTION
PHPDocs make using and debugging eZFind a lot easier, so is a PR that adds/fixes the PHPDoc for most methods. I excluded the methods that override their parent method. IDEs like PHPStorm will then take the PHPDoc from the respective parent.

Cheers
:octocat: Jérôme 
