### PR TITLE
EZP-21767: Changed self::assertType() to self::assertInternalType()

### DIFF
--- a/tests/classes/ezfindfetch_regression.php
+++ b/tests/classes/ezfindfetch_regression.php
@@ -73,7 +73,7 @@ class eZFindFetchRegression extends ezpDatabaseTestCase
             '',
             array( 'SortBy' => array( 'name', 'asc' ) ) + $this->fetchParams );
 
-        self::assertType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
+        self::assertInternalType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
     }
 
     /**
@@ -87,7 +87,7 @@ class eZFindFetchRegression extends ezpDatabaseTestCase
             '',
             array( 'SortBy' => array( 'class_id', 'asc' ) ) + $this->fetchParams );
 
-        self::assertType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
+        self::assertInternalType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
     }
 
     /**
@@ -101,7 +101,7 @@ class eZFindFetchRegression extends ezpDatabaseTestCase
             '',
             array( 'SortBy' => array( 'path', 'asc' ) ) + $this->fetchParams );
 
-        self::assertType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
+        self::assertInternalType( PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $res['SearchResult'] );
     }
 }
 ?>

--- a/tests/classes/ezsolrbase_regression.php
+++ b/tests/classes/ezsolrbase_regression.php
@@ -8,12 +8,24 @@
  */
 class eZSolrBaseRegression extends ezpDatabaseTestCase
 {
+    /**
+     * @var string
+     */
     protected $testURI;
 
+    /**
+     * @var array
+     */
     protected $postParams;
 
+    /**
+     * @var string
+     */
     protected $nonReachableSolr;
 
+    /**
+     * @var eZINI
+     */
     protected $solrINI;
 
     public function setUp()
@@ -51,14 +63,14 @@ class eZSolrBaseRegression extends ezpDatabaseTestCase
 
         $postString = $solrBase->buildPostString( $this->postParams );
         $res = $refMethod->invoke( $solrBase, $solrBase->SearchServerURI.$this->testURI, $postString );
-        self::assertType( PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $res );
+        self::assertInternalType( PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $res );
         self::assertTrue( strpos( $res, '<?xml' ) !== false );
 
         // Now test with postQuery(), that calls sendHTTPRequestRetry() and check result is the same
         $refMethod2 = $refObj->getMethod( 'postQuery' );
         $refMethod2->setAccessible( true );
         $res2 = $refMethod2->invoke( $solrBase, $this->testURI, $postString );
-        self::assertType( PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $res2 );
+        self::assertInternalType( PHPUnit_Framework_Constraint_IsType::TYPE_STRING, $res2 );
         self::assertTrue( strpos( $res2, '<?xml' ) !== false );
     }
 


### PR DESCRIPTION
In newer PHPUnit versions, the method `assertType` is not implemented anymore. This PR changes `self::assertType()` to `self::assertInternalType()`.

https://jira.ez.no/browse/EZP-21767

Cheers
:octocat: Jérôme
