### PR TITLE
EZP-21766: Added missing break that causes unneeded warnings

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -1367,15 +1367,11 @@ class ezfeZPSolrQueryBuilder
                     case 'between':
                     case 'none':
                     case 'all':
-                    {
                         $queryPart['date.other'] = strtolower( $facetDefinition['date.other'] );
-                    }
-
+                        break;
                     default:
-                    {
                         eZDebug::writeWarning( 'Invalid option gived for date.other: ' . $facetDefinition['date.other'],
                                                __METHOD__ );
-                    } break;
                 }
             }
 


### PR DESCRIPTION
The missing break causes the default case to be executed on each iteration, causing a warning to be written even if it doesn't apply.

https://jira.ez.no/browse/EZP-21766

Cheers
:octocat: Jérôme
