### PR TITLE
EZP-21762: Added missing break

### DIFF
--- a/classes/ezfsearchresultinfo.php
+++ b/classes/ezfsearchresultinfo.php
@@ -105,7 +105,7 @@ class ezfSearchResultInfo
                 {
                     return $this->ResultArray['error'];
                 }
-            }
+            } break;
 
             case 'facet_queries':
             {


### PR DESCRIPTION
Due to this missing break, when accessing `ezfSearchResultInfo::attribute( 'error' )` when no errors are present, the facetQueries are returned.

https://jira.ez.no/browse/EZP-21762

Cheers
:octocat: Jérôme
