### PR TITLE
Database independent SQL file provisioning for Unit Tests

### DIFF
--- a/tests/suite.php
+++ b/tests/suite.php
@@ -9,6 +9,10 @@
 
 class eZFindTestSuite extends ezpDatabaseTestSuite
 {
+    protected $sqlFiles = array(
+        array( 'extension/ezfind/sql/', 'schema.sql' ),
+    );
+
     public function __construct()
     {
         parent::__construct();
@@ -37,9 +41,6 @@ class eZFindTestSuite extends ezpDatabaseTestSuite
 
         // make sure extension is enabled and settings are read
         ezpExtensionHelper::load( 'ezfind' );
-
-        $sqlFiles = array( 'extension/ezfind/sql/mysql/mysql.sql' );
-        ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $sqlFiles );
     }
 
     public function tearDown()


### PR DESCRIPTION
At the moment, the eZ Find unit tests would only work with a MySQL backend because the provided SQL files are not database independent.

With this PR, the functionality already provided `ezpDatabaseTestSuite` is used to insert the SQL files into the test database.

Cheers
:octocat: Jérôme
