### PR TITLE
EZP-21764: Don't instantiate eZINI outside of classes

### DIFF
--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -171,9 +171,10 @@ class ezfSolrDocumentFieldBase
      */
     static function getClassAttributeType( eZContentClassAttribute $classAttribute, $subAttribute = null, $context = 'search' )
     {
+        $eZFindIni = eZINI::instance( 'ezfind.ini' );
         // Subattribute-related behaviour here.
         $datatypeString = $classAttribute->attribute( 'data_type_string' );
-        $customMapList = self::$FindINI->variable( 'SolrFieldMapSettings', 'CustomMap' );
+        $customMapList = $eZFindIni->variable( 'SolrFieldMapSettings', 'CustomMap' );
 
         if ( array_key_exists( $datatypeString, $customMapList ) )
         {
@@ -187,19 +188,19 @@ class ezfSolrDocumentFieldBase
         }
 
         // Fallback #1: single-fielded datatype behaviour here.
-        $datatypeMapList = self::$FindINI->variable( 'SolrFieldMapSettings', eZSolr::$fieldTypeContexts[$context] );
+        $datatypeMapList = $eZFindIni->variable( 'SolrFieldMapSettings', eZSolr::$fieldTypeContexts[$context] );
         if ( !empty( $datatypeMapList[$classAttribute->attribute( 'data_type_string' )] ) )
         {
             return $datatypeMapList[$classAttribute->attribute( 'data_type_string' )];
         }
         // Fallback #2: search field datatypemap (pre ezfind 2.2 behaviour)
-        $datatypeMapList = self::$FindINI->variable( 'SolrFieldMapSettings', 'DatatypeMap' );
+        $datatypeMapList = $eZFindIni->variable( 'SolrFieldMapSettings', 'DatatypeMap' );
         if ( !empty( $datatypeMapList[$classAttribute->attribute( 'data_type_string' )] ) )
         {
             return $datatypeMapList[$classAttribute->attribute( 'data_type_string' )];
         }
         // Fallback #3: return default field.
-        return self::$FindINI->variable( 'SolrFieldMapSettings', 'Default' );
+        return $eZFindIni->variable( 'SolrFieldMapSettings', 'Default' );
     }
 
     /**
@@ -216,8 +217,10 @@ class ezfSolrDocumentFieldBase
      */
     public static function getFieldNameList( eZContentClassAttribute $classAttribute, $exclusiveTypeFilter = array() )
     {
+        $eZFindIni = eZINI::instance( 'ezfind.ini' );
+        
         $datatypeString = $classAttribute->attribute( 'data_type_string' );
-        $customMapList = self::$FindINI->variable( 'SolrFieldMapSettings', 'CustomMap' );
+        $customMapList = $eZFindIni->variable( 'SolrFieldMapSettings', 'CustomMap' );
 
         if ( array_key_exists( $datatypeString, $customMapList ) )
         {
@@ -267,8 +270,10 @@ class ezfSolrDocumentFieldBase
      */
     public static function getFieldName( eZContentClassAttribute $classAttribute, $subAttribute = null, $context = 'search' )
     {
+        $eZFindIni = eZINI::instance( 'ezfind.ini' );
+        
         $datatypeString = $classAttribute->attribute( 'data_type_string' );
-        $customMapList = self::$FindINI->variable( 'SolrFieldMapSettings', 'CustomMap' );
+        $customMapList = $eZFindIni->variable( 'SolrFieldMapSettings', 'CustomMap' );
 
         if ( array_key_exists( $datatypeString, $customMapList ) )
         {
@@ -297,10 +302,12 @@ class ezfSolrDocumentFieldBase
      */
     static function getInstance( eZContentObjectAttribute $objectAttribute )
     {
+        $eZFindIni = eZINI::instance( 'ezfind.ini' );
+        
         $datatypeString = $objectAttribute->attribute( 'data_type_string' );
 
         // Check if using custom handler.
-        $customMapList = self::$FindINI->variable( 'SolrFieldMapSettings', 'CustomMap' );
+        $customMapList = $eZFindIni->variable( 'SolrFieldMapSettings', 'CustomMap' );
         if ( isset( $customMapList[$datatypeString] ) )
         {
             $fieldBaseClass = $customMapList[$datatypeString];
@@ -393,7 +400,9 @@ class ezfSolrDocumentFieldBase
     {
         // base name of subfields ends with self::SUBATTR_FIELD_PREFIX so
         // that it's possible to differentiate those fields in schema.xml
-        return self::$DocumentFieldName->lookupSchemaName( self::SUBATTR_FIELD_PREFIX . $classAttribute->attribute( 'identifier' )
+        $documentFieldName = self::getDocumentFieldName();
+
+        return $documentFieldName->lookupSchemaName( self::SUBATTR_FIELD_PREFIX . $classAttribute->attribute( 'identifier' )
                                                             . self::SUBATTR_FIELD_SEPARATOR . $subfieldName . self::SUBATTR_FIELD_SEPARATOR,
                                                            $type );
     }
@@ -412,7 +421,9 @@ class ezfSolrDocumentFieldBase
      */
     public static function generateAttributeFieldName( eZContentClassAttribute $classAttribute, $type )
     {
-        return self::$DocumentFieldName->lookupSchemaName( self::ATTR_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ),
+        $documentFieldName = self::getDocumentFieldName();
+
+        return $documentFieldName->lookupSchemaName( self::ATTR_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ),
                                                            $type );
     }
 
@@ -430,7 +441,9 @@ class ezfSolrDocumentFieldBase
      */
     public static function generateMetaFieldName( $baseName, $context = 'search' )
     {
-        return self::$DocumentFieldName->lookupSchemaName( self::META_FIELD_PREFIX . $baseName,
+        $documentFieldName = self::getDocumentFieldName();
+
+        return $documentFieldName->lookupSchemaName( self::META_FIELD_PREFIX . $baseName,
                                                            eZSolr::getMetaAttributeType( $baseName, $context ) );
     }
 
@@ -452,7 +465,9 @@ class ezfSolrDocumentFieldBase
      */
     public static function generateSubmetaFieldName( $baseName, eZContentClassAttribute $classAttribute )
     {
-        return self::$DocumentFieldName->lookupSchemaName( self::SUBMETA_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ) . self::SUBATTR_FIELD_SEPARATOR . $baseName . self::SUBATTR_FIELD_SEPARATOR,
+        $documentFieldName = self::getDocumentFieldName();
+
+        return $documentFieldName->lookupSchemaName( self::SUBMETA_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ) . self::SUBATTR_FIELD_SEPARATOR . $baseName . self::SUBATTR_FIELD_SEPARATOR,
                                                            eZSolr::getMetaAttributeType( $baseName ) );
     }
 
@@ -478,9 +493,19 @@ class ezfSolrDocumentFieldBase
             return false;
     }
 
+    /**
+     * Sets the static DocumentFieldName instance
+     *
+     * @return ezfSolrDocumentFieldName
+     */
+    public static function getDocumentFieldName()
+    {
+        return self::$DocumentFieldName = ( self::$DocumentFieldName instanceof ezfSolrDocumentFieldName ) ?
+            self::$DocumentFieldName : new ezfSolrDocumentFieldName();
+    }
+
     /// Vars
     public $ContentObjectAttribute;
-    static $FindINI;
     static $DocumentFieldName;
 
     /**
@@ -529,8 +554,5 @@ class ezfSolrDocumentFieldBase
      */
     const SUBATTR_FIELD_SEPARATOR = '___';
 }
-
-ezfSolrDocumentFieldBase::$FindINI = eZINI::instance( 'ezfind.ini' );
-ezfSolrDocumentFieldBase::$DocumentFieldName = new ezfSolrDocumentFieldName();
 
 ?>


### PR DESCRIPTION
At the moment, `eZINI` instances for `ezfind.ini`, `solr.ini` and `site.ini` get created outside of the the classes `ezfSolrDocumentFieldBase` and `ezfeZPSolrQueryBuilder`, even when their containing PHP files just get included through the autoloader. This can cause problems, e.g. in the context of Unit Tests when this happens before the INI files get overriden by other processes.

This PR preserves the static class variables, but ensures that they get instantiated inside the classes only.

If have thought about converting them to local variables, but wanted to make sure that derived classes, that access them, don't get problems.

Cheers
:octocat: Jérôme

PS: This PR is part of a process to make the eZ Find Unit Tests work again.