### PR TITLE
EZP-21765: Fix number of parameters to match parent

### DIFF
--- a/classes/ezfsolrdocumentfielddummyexample.php
+++ b/classes/ezfsolrdocumentfielddummyexample.php
@@ -112,7 +112,7 @@ class ezfSolrDocumentFieldDummyExample extends ezfSolrDocumentFieldBase
     /**
      * @see ezfSolrDocumentFieldBase::getFieldName()
      */
-    public static function getFieldName( eZContentClassAttribute $classAttribute, $subAttribute = null )
+    public static function getFieldName( eZContentClassAttribute $classAttribute, $subAttribute = null, $context = 'search' )
     {
         if ( $subAttribute and
              $subAttribute !== '' and
@@ -162,7 +162,7 @@ class ezfSolrDocumentFieldDummyExample extends ezfSolrDocumentFieldBase
     /**
      * @see ezfSolrDocumentFieldBase::getClassAttributeType()
      */
-    static function getClassAttributeType( eZContentClassAttribute $classAttribute, $subAttribute = null )
+    static function getClassAttributeType( eZContentClassAttribute $classAttribute, $subAttribute = null, $context = 'search' )
     {
         if ( $subAttribute and
              $subAttribute !== '' and


### PR DESCRIPTION
When running the eZ Find Unit Test Suite, errors are thrown because `getClassAttributeType()` and `getFieldName()` don't match their parents in `ezfSolrDocumentFieldDummyExample`.

This PR fixes that.

https://jira.ez.no/browse/EZP-21765

Cheers
:octocat: Jérôme
