### PR TITLE
EZP-21779: Removed duplicate table creation

### DIFF
--- a/tests/classes/ezfindelevateconfiguration_test.php
+++ b/tests/classes/ezfindelevateconfiguration_test.php
@@ -6,14 +6,6 @@ class eZFindElevateConfigurationTest extends ezpDatabaseTestCase
 {
     protected $backupGlobals = false;
 
-    protected $sqlFiles = array( 'extension/ezfind/sql/mysql/mysql.sql' );
-
-    public function setUp()
-    {
-        parent::setUp();
-        ezpTestDatabaseHelper::insertSqlData( $this->sharedFixture, $this->sqlFiles );
-    }
-
     /**
      * Data provider for testGetRuntimeQueryParameters
      */


### PR DESCRIPTION
The SQL files for the eZ Find Test Suite are already imported in the `setUp()` method of the eZ Find Test Suite, but get re-imported in the eZFindElevateConfigurationTest class. This causes an SQL error because the table already exists at this point.

https://jira.ez.no/browse/EZP-21779

Cheers
:octocat: Jérôme
