### PR TITLE
EZP-21939: eZ Find should return errors when Solr is down

### DIFF
--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -141,7 +141,7 @@ class eZSolrBase
      * @param string $languageCodes A language code string
      * @param string $contentType POST content type
      *
-     * @return string Result of HTTP Request ( without HTTP headers )
+     * @return string|boolean Result of HTTP Request ( without HTTP headers ), false if the request fails.
      */
     protected function postQuery( $request, $postData, $contentType = self::DEFAULT_REQUEST_CONTENTTYPE )
     {
@@ -155,22 +155,22 @@ class eZSolrBase
      * @param string $request request name
      * @param string $getParams HTTP GET parameters, as an associative array
      *
-     * @return Result of HTTP Request ( without HTTP headers )
+     * @return string|boolean Result of HTTP Request ( without HTTP headers ), false if the request fails.
      */
     function getQuery( $request, $getParams )
     {
         return $this->sendHTTPRequestRetry( eZSolrBase::buildHTTPGetQuery( $request, $getParams ) );
     }
 
-    /*!
-      OBS ! Experimental.
 
-      Can be used for anything, uses the post method
-      ResponseWriter wt=php is default, alternative: json or phps
-
-      \param $request refers to the request handler called
-      \param $params is an array of post variables to include. The actual values
-             are urlencoded in the buildPostString() call
+    /**
+     * @note OBS ! Experimental.
+     *
+     * @param $request refers to the request handler called
+     * @param $params is an array of post variables to include.
+     *        The actual values are urlencoded in the buildPostString() call
+     *
+     * @return array|boolean Result of SOLR request, false if the request fails or invalid results.
      */
     function rawSolrRequest ( $request = '', $params = array(), $wt = 'php' )
     {

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1005,11 +1005,10 @@ class eZSolr implements ezpSearchEngine
         else
         {
             eZDebug::accumulatorStop( 'Search' );
-            return array(
-                'SearchResult' => false,
-                'SearchCount' => 0,
-                'StopWordArray' => array(),
-                'SearchExtras' => new ezfSearchResultInfo( array( 'error' => ezpI18n::tr( 'ezfind', $error ) ) ) );
+
+            // If resultArray is false, SOLR was not available or did not respond - handle as error.
+            $errorModule = eZModule::exists( 'error' );
+            return $errorModule->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
         }
     }
 
@@ -1090,11 +1089,9 @@ class eZSolr implements ezpSearchEngine
         }
         else
         {
-            return array(
-                'SearchResult' => false,
-                'SearchCount' => 0,
-                'StopWordArray' => array(),
-                'SearchExtras' => new ezfSearchResultInfo( array( 'error' => ezpI18n::tr( 'ezfind', $error ) ) ) );
+            // If resultArray is false, SOLR was not available or did not respond - handle as error.
+            $errorModule = eZModule::exists( 'error' );
+            return $errorModule->handleError( eZError::KERNEL_NOT_AVAILABLE, 'kernel' );
         }
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21939

If SOLR server is not available, return an actual error, which makes it possible to handle the condition further.
In practice, this changes the returned HTTP status (200 => 404), but the behavior can be further customized in error.ini `[ErrorSettings]`

Testing:  manual
