### PR TITLE
Fix EZP-19991: Allow RawFilterList to be set at the siteaccess level

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -307,10 +307,13 @@ class ezfeZPSolrQueryBuilder
         }
 
         //add raw filters
-        $rawFilters = self::$FindINI->variable( 'SearchFilters', 'RawFilterList' );
-        if ( is_array( $rawFilters ) )
+        if ( self::$FindINI->hasVariable( 'SearchFilters', 'RawFilterList' ) )
         {
-            $filterQuery = array_merge( $filterQuery, $rawFilters );
+            $rawFilters = self::$FindINI->variable( 'SearchFilters', 'RawFilterList' );
+            if ( is_array( $rawFilters ) )
+            {
+                $filterQuery = array_merge( $filterQuery, $rawFilters );
+            }
         }
 
         // Build and get facet query prameters.
@@ -790,10 +793,13 @@ class ezfeZPSolrQueryBuilder
         }
 
         //add raw filters
-        $rawFilters = self::$FindINI->variable( 'SearchFilters', 'RawFilterList' );
-        if ( is_array( $rawFilters ) )
+        if ( self::$FindINI->hasVariable( 'SearchFilters', 'RawFilterList' ) )
         {
-            $filterQuery = array_merge( $filterQuery, $rawFilters );
+            $rawFilters = self::$FindINI->variable( 'SearchFilters', 'RawFilterList' );
+            if ( is_array( $rawFilters ) )
+            {
+                $filterQuery = array_merge( $filterQuery, $rawFilters );
+            }
         }
 
         // Build and get facet query prameters.

--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -241,7 +241,7 @@ ClassIdentifierList[]
 #Search filters to be applied for every query made
 #Expert settings!
 #Currently support for one filter type, a raw Solr query string
-RawFilterList[]
+#RawFilterList[]
 #Example to exclude certain classes
 #RawFilterList[]=meta_class_identifier_s:[* TO *] -meta_class_identifier_s:(folder article)
 


### PR DESCRIPTION
RawFilterList is reset by the default ezfind.ini when eZ Find is activated globally. By commenting it out we allow it to be set at the siteaccess level.
