### PR TITLE
Fix EZP-16372: fix the check for ezfind.ini\[IndexOptions]\DisableDelete...

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -866,7 +866,7 @@ class eZSolr implements ezpSearchEngine
          * the parameter $commit it is not set
          * Default behaviour is as before
          */
-        if ( !isset( $commit ) && ( $this->FindINI->variable( 'IndexOptions', 'DisableDeleteCommits' ) === 'true' ) )
+        if ( $this->FindINI->variable( 'IndexOptions', 'DisableDeleteCommits' ) === 'true' )
         {
             $commit = false;
         }


### PR DESCRIPTION
...Commits

The prototypes of removeObject() and removeObjectById() differ between eZSearch and eZFind, i.e:

static function removeObject( $contentObject, $commit = true )
versus
function removeObject( $contentObject, $commit = null )

When eZContentObject calls eZSearch::removeObjectById( $delID ), removeObjectById() is called by eZSearch with its default value, $commit = true.

So the check :
if ( !isset( $commit ) && ( $this->FindINI->variable( 'IndexOptions', 'DisableDeleteCommits' ) === 'true' ) )

is always false, because $commit is always defined.

So simply remove this check, and let ezfind.ini[IndexOptions]\DisableDeleteCommits determine whether we have to commit.
