### PR TITLE
EZP-22121: add support for commitWithin on delete operations

### DIFF
--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -361,11 +361,18 @@ class eZSolrBase
      *              $query will be used to delete documents instead.
      * @param string $query Solr Query. This will be ignored if $docIDs is set.
      * @param bool $optimize set to true to perform a solr optimize after delete
+     * @param integer $commitWithin specifies within how many milliseconds a commit should occur if no other commit
      * @return bool
      **/
-    function deleteDocs ( $docIDs = array(), $query = false, $commit = true,  $optimize = false )
+    function deleteDocs ( $docIDs = array(), $query = false, $commit = true,  $optimize = false, $commitWithin = 0 )
     {
         $postString = '<delete>';
+
+        if ( is_numeric( $commitWithin ) && $commitWithin > 0 )
+        {
+            $postString = '<delete commitWithin="' . $commitWithin . '">';
+        }
+
         if ( empty( $query ) )
         {
             foreach ( $docIDs as $docID )

--- a/settings/ezfind.ini
+++ b/settings/ezfind.ini
@@ -182,7 +182,7 @@ OptimizeOnCommit=enabled
 ## DisableDirectCommits: if true, another mechanism must be enabled to do commits: cronjob,
 # solrconf.xml or by giving CommitWithin a positive value (expressed in milliseconds)
 DisableDirectCommits=false
-## If set to a positive value will add those delays with every addObject call
+## If set to a positive value will add those delays with every addObject/removeObject call
 # if set to 0 (default), it will be ignored
 # the unit is milliseconds
 CommitWithin=0


### PR DESCRIPTION
According to https://issues.apache.org/jira/browse/SOLR-2280, Solr 3.6 supports a commitWithin parameter for delete operations.
It has exactly the same meaning as the one on add operation, i.e. letting the client ask Solr to make sure the command gets committed within a certain time.
