### PR TITLE
Make submeta attributes multivalued

### DIFF
--- a/classes/ezfsolrdocumentfieldbase.php
+++ b/classes/ezfsolrdocumentfieldbase.php
@@ -475,7 +475,7 @@ class ezfSolrDocumentFieldBase
      */
     public static function generateSubmetaFieldName( $baseName, eZContentClassAttribute $classAttribute )
     {
-        return self::$DocumentFieldName->lookupSchemaName( self::SUBMETA_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ) . self::SUBATTR_FIELD_SEPARATOR . $baseName,
+        return self::$DocumentFieldName->lookupSchemaName( self::SUBMETA_FIELD_PREFIX . $classAttribute->attribute( 'identifier' ) . self::SUBATTR_FIELD_SEPARATOR . $baseName . self::SUBATTR_FIELD_SEPARATOR,
                                                            eZSolr::getMetaAttributeType( $baseName ) );
     }
 


### PR DESCRIPTION
When indexing a object relation list datatype, eZ Find pushes the meta information for all the related objects in one single solr submeta attribute.
The submeta name definition uses the default _non-multivalued_ suffix and makes the indexing fail for the whole object.

This pull request adds the subattribute prefix to the submeta field name.

Aside question: Do we actually need to index the meta information for the related objects? 
I don't see any real-life situation where this information could be used in conjunction with Solr.
