### PR TITLE
Fix EZP-22391 incorrect limitation if 'content/read' = no

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -1559,7 +1559,7 @@ class ezfeZPSolrQueryBuilder
         {
             if ( empty( $limitation ) )
             {
-                return false;
+                $limitation['accessWord'] = 'yes';
             }
         }
         else


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22391

When performing a search, the SOLR query uses `policyLimitationFilterQuery()`, which
checks custom limitation parameter, or - by default - the user access to 'content/read'.
However, if access to content/read = 'no' (no policy/limitation exists) the filter is not correctly generated.

This changes causes the the correct filter (`NOT *:*`) to be returned in this case.
