### PR TITLE
Fix EZP-22767: Added ezcss_require when using autocomplete.

### DIFF
--- a/design/ezdemo/templates/content/search.tpl
+++ b/design/ezdemo/templates/content/search.tpl
@@ -342,6 +342,7 @@
 
 
 {ezscript_require( array('ezjsc::yui3', 'ezajax_autocomplete.js') )}
+{ezcss_require( 'ezajax_autocomplete.css' )}
 
 <script type="text/javascript">
 

--- a/design/ezflow/override/templates/block/search.tpl
+++ b/design/ezflow/override/templates/block/search.tpl
@@ -14,6 +14,7 @@
 
 <div id="search-results-{$block.id}"></div>
 {ezscript_require( array( 'ezjsc::jquery', 'ezjsc::yui3', 'ezjsc::yui3io', 'ezjsc::yui2', 'ezajaxsearch.js', 'ezajax_autocomplete.js' ) )}
+{ezcss_require( 'ezajax_autocomplete.css' )}
 
 
 <script type="text/javascript">

--- a/design/ezwebin/templates/content/search.tpl
+++ b/design/ezwebin/templates/content/search.tpl
@@ -338,6 +338,7 @@
 </div>
 
 {ezscript_require( array('ezjsc::yui3', 'ezajax_autocomplete.js') )}
+{ezcss_require( 'ezajax_autocomplete.css' )}
 <script type="text/javascript">
 
 YUI(YUI3_config).use('ezfindautocomplete', function (Y) {ldelim}

--- a/design/ezwebin/templates/page_header_searchbox.tpl
+++ b/design/ezwebin/templates/page_header_searchbox.tpl
@@ -20,6 +20,7 @@
 {if $pagedata.is_edit|not()}
 
 {ezscript_require( array('ezjsc::yui3', 'ezajax_autocomplete.js') )}
+{ezcss_require( 'ezajax_autocomplete.css' )}
 <script type="text/javascript">
 
 YUI(YUI3_config).use('ezfindautocomplete', function (Y) {ldelim}


### PR DESCRIPTION
## Description

When autocomplete in a module is called from the new stack, js files included with ezscript_require were not loaded. This is fixed in https://github.com/ezsystems/ezpublish-kernel/pull/833

CSS files are also missing. In order to load them within a module, they need to be required within the page and not in the config files.
## Test

Manual test
