### PR TITLE
Fix EZP-22859: Object Relations versions not saved correctly in Solr

### DIFF
--- a/classes/ezfsolrdocumentfieldobjectrelation.php
+++ b/classes/ezfsolrdocumentfieldobjectrelation.php
@@ -297,12 +297,15 @@ class ezfSolrDocumentFieldObjectRelation extends ezfSolrDocumentFieldBase
                     $subObjectID = $relationItem['contentobject_id'];
                     if ( !$subObjectID )
                         continue;
-                    $subObject = eZContentObjectVersion::fetchVersion( $relationItem['contentobject_version'], $subObjectID );
+
+                    // Using last version of object (version inside xml data is the original version)
+                    $subObject = eZContentObject::fetch( $subObjectID );
+
                     if ( !$subObject || $relationItem['in_trash'] )
                         continue;
 
                     // 1st create aggregated metadata fields
-                    $metaAttributeValues = eZSolr::getMetaAttributesForObject( $subObject->attribute( 'contentobject' ) );
+                    $metaAttributeValues = eZSolr::getMetaAttributesForObject( $subObject );
                     foreach ( $metaAttributeValues as $metaInfo )
                     {
                         $submetaFieldName = ezfSolrDocumentFieldBase::generateSubmetaFieldName( $metaInfo['name'], $contentClassAttribute );


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22859
## Description

While indexing object relations, ezfind was using object versions contained in the attribute's xml_data field. The problem is that this version is the version of the object when it was first added to the relation, not the current one. This patch fixes this by fetching the current object instead of the version from the xml_data.
## Tests

Manual tests
