### PR TITLE
EZP-23003: Don't regenerate session id when switching users

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -488,10 +488,10 @@ class eZSolr implements ezpSearchEngine
             $anonymousUserID = $this->SiteINI->variable( 'UserSettings', 'AnonymousUserID' );
             $currentUserID = eZUser::currentUserID();
             $user = eZUser::instance( $anonymousUserID );
-            eZUser::setCurrentlyLoggedInUser( $user, $anonymousUserID );
+            eZUser::setCurrentlyLoggedInUser( $user, $anonymousUserID, eZUser::NO_SESSION_REGENERATE );
             $anonymousAccess = $contentObject->attribute( 'can_read' );
             $user = eZUser::instance( $currentUserID );
-            eZUser::setCurrentlyLoggedInUser( $user, $currentUserID );
+            eZUser::setCurrentlyLoggedInUser( $user, $currentUserID, eZUser::NO_SESSION_REGENERATE );
             $anonymousAccess = $anonymousAccess ? 'true' : 'false';
         }
         else


### PR DESCRIPTION
This PR addresses https://jira.ez.no/browse/EZP-23003

When using eZ Multiupload in combination with eZ Find, the current user gets logged out after the first uploaded image.

The reason seems to be the following:
- When accessing the muliupload page, the current user has a session id which is sent with each AJAX upload request
- When the contentobject for the image is created, it gets added to the search index
  - There is a check if the anonymous user is allowed to see this object - only if it is, the object will be added to the index
  - To perform the check, the current user is changed to anonymous, the access is checked, and the current user is changed back to the original user
- During this process, the session id is regenerated, but the AJAX requests are still posting the previous session id
- The next AJAX request will then not be recognized as sent by the original user, and be treated as coming from anonymous and redirecting to the User Login (HTML) page (with a 200 HTTP status code, by the way)

Although this is an issue occurring with eZ Multiupload, I believe this is the right place to change the behaviour - the current user is being changed here only to check if the anonymous user is allowed to do something; a check alone shouldn't modify an integral part of the current user session… I hope you agree and merge this change :).

Cheers
:octocat: Jérôme
