### PR TITLE
EZP-23203: Improve handling of unexpected Solr response

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1498,6 +1498,15 @@ class eZSolr implements ezpSearchEngine
         if ( !empty( $resultArray ) )
         {
             $result = $resultArray['response'];
+            if ( !is_array( $result ) ||
+                 !isset( $result['maxScore'] ) ||
+                 !isset( $result['docs'] ) ||
+                 !is_array( $result['docs'] ) )
+            {
+                eZDebug::writeError( 'Unexpected response from Solr: ' . var_export( $result, true ), __METHOD__ );
+                return $objectRes;
+            }
+
             $maxScore = $result['maxScore'];
             $docs = $result['docs'];
             $localNodeIDList = array();


### PR DESCRIPTION
Sometimes Solr answers with such a response :

array(
  'responseHeader'=>array(
    'status'=>0,
    'QTime'=>1),
  'response'=>null,
  'interestingTerms'=>array())

So add some sanity checks to avoid segfault.
