### PR TITLE
EZP-22621 : fix warning in logs about missing files in schema.xml

### DIFF
--- a/java/solr/ezp-default/conf/custom-copyfields.xml
+++ b/java/solr/ezp-default/conf/custom-copyfields.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" ?>
+<schema name="ezfind-custom-copyfields" version="1.5">
+</schema>

--- a/java/solr/ezp-default/conf/custom-fields.xml
+++ b/java/solr/ezp-default/conf/custom-fields.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" ?>
+<schema name="ezfind-custom-fields" version="1.5">
+</schema>


### PR DESCRIPTION
This PR intends to fix the warning in the logs. Two files are missing in ezp-default core.
