### PR TITLE
Implemented: EZP-23260 eZ Find update index script shouldn't run if eZ F...

### DIFF
--- a/bin/php/updatesearchindexsolr.php
+++ b/bin/php/updatesearchindexsolr.php
@@ -97,6 +97,13 @@ class ezfUpdateSearchIndexSolr
         );
         $this->Script->initialize();
 
+        // check if ezfind is enabled and exit if not
+        if ( ! in_array( 'ezfind', eZExtension::activeExtensions() ) )
+        {
+            $this->CLI->error( 'eZ Find extension is not enabled and because of that index process will fail. Please enable it and run this script again.' );
+            $this->Script->shutdown( 0 );
+        }
+
         // Fix siteaccess
         $siteAccess = $this->Options['siteaccess'] ? $this->Options['siteaccess'] : false;
         if ( $siteAccess )


### PR DESCRIPTION
...ind is not enabled

Implements: https://jira.ez.no/browse/EZP-23260

When eZ Find is not enable you can still run the inde process, but as ezfind inis won't be taken in account, index process will fail. 

This patch finish the process before trying to index anything if eZ Find is not enabled. 
