### PR TITLE
Issue 23186 elevation error on synchronize

### DIFF
--- a/java/solr/ezp-default/conf/schema.xml
+++ b/java/solr/ezp-default/conf/schema.xml
@@ -401,10 +401,13 @@
  <!-- eZ Find: This field type is dedicated to Elevate.  -->
     <fieldType name="elevate_string" stored="false" indexed="false" class="solr.TextField">
           <analyzer>
-              <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+              <tokenizer class="solr.KeywordTokenizerFactory"/>
               <filter class="solr.LowerCaseFilterFactory"/>
+              <!-- Alternative configuration for elevation, adding a normalisation step for accented chracters based on the ICU library -->
+              <!-- <filter class="solr.ICUFoldingFilterFactory"/> -->
           </analyzer>
     </fieldType>
+
 
 <!-- eZ Find: This field type is dedicated to ez publish keywords.  -->
     <fieldtype name="keyword" class="solr.TextField" positionIncrementGap="100">


### PR DESCRIPTION
Fix:
-Changed tokenisation step to the use of a keyword tokenizer class, which preserves whitespace. In this way, multiple elevate strings which share one or more keywords can be used without causing collisions in the internal Solr elevate function

Upgrading:
- After applying this patch, the synchronize action in the ezfind elevate panel of the admin interface should be  executed once more
- No re-indexing is necessary

Alternative config:
- In this patch, also an optional step can be activated that normalizes accented characters and more across languages by using the ICU library. To activate, simply uncomment it.
