### PR TITLE
Fix EZP-23353: Disconnect cluster DB before forking new process

### DIFF
--- a/bin/php/updatesearchindexsolr.php
+++ b/bin/php/updatesearchindexsolr.php
@@ -360,6 +360,9 @@ class ezfUpdateSearchIndexSolr
     {
         eZDB::setInstance( null );
 
+        // Prepare DB-based cluster handler for fork (it will re-connect DB automatically).
+        eZClusterFileHandler::preFork();
+
         $pid = pcntl_fork();
 
         // reinitialize DB after fork


### PR DESCRIPTION
JIRA: 
https://jira.ez.no/browse/EZP-23353

Problem:
When running `updatesearchindexsolr.php` in a DB-based cluster environment (DFS), 
the cluster DB connection is created before the script forks new process(es), which will cause `MySQL server has gone away` errors.

Fix:
If using a `ezpDatabaseBasedClusterFileHandler`, disconnect before forking.

Tests:
Manual
