### PR TITLE
Fix EZP-23412: setting a section indexes content, even with DelayedIndexing

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -602,7 +602,7 @@ class eZSolr implements ezpSearchEngine
             $urlAlias = eZFunctionHandler::execute( 'switchlanguage', 'url_alias', array( 'node_id' => $mainNodeID, 'locale' => $languageCode ) );
             // Add main url_alias
             $doc->addField( ezfSolrDocumentFieldBase::generateMetaFieldName( 'main_url_alias' ), $urlAlias );
-            
+
             // Add main path_string
             $doc->addField( ezfSolrDocumentFieldBase::generateMetaFieldName( 'main_path_string' ), $mainNode->attribute( 'path_string' ) );
 
@@ -1386,7 +1386,7 @@ class eZSolr implements ezpSearchEngine
     public function updateNodeSection( $nodeID, $sectionID )
     {
         $contentObject = eZContentObject::fetchByNodeID( $nodeID );
-        $this->addObject( $contentObject );
+        eZContentOperationCollection::registerSearchObject( $contentObject->ID );
     }
 
     /**
@@ -1406,7 +1406,7 @@ class eZSolr implements ezpSearchEngine
             // section id or the content object may come from the memory cache
             // make sure the section_id is the right one
             $object->setAttribute( 'section_id', $sectionID );
-            $this->addObject( $object );
+            eZContentOperationCollection::registerSearchObject( $id );
         }
     }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23412

Updating an object's section automatically indexes the object, not respecting the `DelayedIndexing` flag in `SearchSettings`.

This "defers" the operation to `eZContentOperationCollection::registerSearchObject`, which handles all the necessary work.

Tests: manual.
