### PR TITLE
Fixed EZP-23407: an additional boolean is added in the output result set...

### DIFF
--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -422,12 +422,16 @@ class ezfeZPSolrQueryBuilder
             $filterQuery = array( $fqString );
         }
 
+        // Document transformer fields since eZ Find 5.4
+        $docTransformerFields = array( '[elevated]' );
+
         $fieldsToReturnString = eZSolr::getMetaFieldName( 'guid' ) . ' ' . eZSolr::getMetaFieldName( 'installation_id' ) . ' ' .
                 eZSolr::getMetaFieldName( 'main_url_alias' ) . ' ' . eZSolr::getMetaFieldName( 'installation_url' ) . ' ' .
                 eZSolr::getMetaFieldName( 'id' ) . ' ' . eZSolr::getMetaFieldName( 'main_node_id' ) . ' ' .
                 eZSolr::getMetaFieldName( 'language_code' ) . ' ' . eZSolr::getMetaFieldName( 'name' ) .
                 ' score ' . eZSolr::getMetaFieldName( 'published' ) . ' ' . eZSolr::getMetaFieldName( 'path_string' ) . ' ' .
                 eZSolr::getMetaFieldName( 'main_path_string' ) . ' ' . eZSolr::getMetaFieldName( 'is_invisible' ) . ' ' .
+                implode( ' ', $docTransformerFields) . ' ' .
                 implode( ' ', $extraFieldsToReturn );
 
         if ( ! $asObjects )

--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -24,7 +24,9 @@ class eZFindResultNode extends eZContentObjectTreeNode
                                                'published',
                                                'language_code',
                                                'highlight',
-                                               'score_percent' );
+                                               'score_percent',
+                                               'elevated'
+                );
     }
 
     /*!

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1656,6 +1656,7 @@ class eZSolr implements ezpSearchEngine
                     }
                     $emit['highlight'] = isset( $highLights[$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'guid' )]] ) ?
                                          $highLights[$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'guid' )]] : null;
+                    $emit['elevated'] = ( isset($doc['[elevated]']) ? $doc['[elevated]'] === true : false );
                     $objectRes[] = $emit;
                     unset( $emit );
                     continue;
@@ -1739,6 +1740,7 @@ class eZSolr implements ezpSearchEngine
                  */
                 $maxScore != 0 ? $resultTree->setAttribute( 'score_percent', (int) ( ( $doc['score'] / $maxScore ) * 100 ) ) : $resultTree->setAttribute( 'score_percent', 100 );
                 $resultTree->setAttribute( 'language_code', $doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'language_code' )] );
+                $resultTree->setAttribute( 'elevated', ( isset($doc['[elevated]']) ? $doc['[elevated]'] === true : false ) );
                 $objectRes[] = $resultTree;
             }
         }


### PR DESCRIPTION
... to mark if a result is elevated or not

The property is named "elevated" and can be used to control rendering in output templates. 
