### PR TITLE
Fix EZP-23603: ignore node visibility when checking subtree count

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1431,7 +1431,14 @@ class eZSolr implements ezpSearchEngine
     {
         $node = eZContentObjectTreeNode::fetch( $nodeID );
         $this->addObject( $node->attribute( 'object' ) );
-        if ( $node->childrenCount( false ) )
+
+        $params = array(
+            'Depth'             => 1,
+            'DepthOperator'     => 'eq',
+            'Limitation'        => array(),
+            'IgnoreVisibility'  => true,
+        );
+        if ( $node->subTreeCount( $params ) > 0 )
         {
             $pendingAction = new eZPendingActions(
                 array(


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23603

When `eZSolr::updateNodeVisibility()` is called, a pending action is created if the node has any child nodes.
However, this only works when `IgnoreVisibility` is `true` (admin siteaccess).

This fix specifically sets the `IgnoreVisibility` param. to count child nodes, so that the function works properly f.e. in a frontend siteaccess.
