### PR TITLE
Fix EZP-23617: Add subtree and class filters on eZ Find autocomplete

### DIFF
--- a/classes/ezfindservercallfunctions.php
+++ b/classes/ezfindservercallfunctions.php
@@ -154,6 +154,43 @@ class eZFindServerCallFunctions
                 $params['fq'] = 'meta_language_code_ms:(' . implode( ' OR ', $validLanguages ) . ')';
             }
 
+            //build the query part for the subtree limitation
+            if ( isset( $args[2] ) && (int)$args[2] )
+            {
+                if ( isset( $params['fq'] ) && $params['fq'] )
+                {
+                    $params['fq'] .= ' AND ';
+                }
+                $params['fq'] .= eZSolr::getMetaFieldName( 'path' ) . ':' . (int)$args[2];
+            }
+
+            //build the query part for the class limitation
+            if ( isset( $args[3] ) && $args[3] )
+            {
+                if ( isset( $params['fq'] ) && $params['fq'] )
+                {
+                    $params['fq'] .= ' AND ';
+                }
+                $classes = explode( ',', $args[3] );
+                $classQueryParts = array();
+                foreach( $classes as $class )
+                {
+                    if ( is_string( $class ) )
+                    {
+                        if ( $class = eZContentClass::fetchByIdentifier( $class ) )
+                        {
+                            $classQueryParts[] = eZSolr::getMetaFieldName( 'contentclass_id' ) . ':' . $class->attribute( 'id' );
+                        }
+                    }
+                    else
+                    {
+                        $classQueryParts[] = eZSolr::getMetaFieldName( 'contentclass_id' ) . ':' . $class;
+                    }
+                }
+                $classQueryParts = implode( ' OR ', $classQueryParts );
+                $params['fq'] .= '(' . $classQueryParts . ')';
+            }
+
             $solrBase = new eZSolrBase( $fullSolrURI );
             $result = $solrBase->rawSolrRequest( '/select', $params, 'json' );
 

--- a/design/standard/javascript/ezajax_autocomplete.js
+++ b/design/standard/javascript/ezajax_autocomplete.js
@@ -19,6 +19,17 @@ YUI.add('ezfindautocomplete', function (Y) {
             source: conf.url
         });
 
+        // Build Ajax request URL string, passed to AutoComplete as the requestTemplate
+        var urlString = "::{query}::" + conf.resultLimit + "::";
+        if( typeof conf.subtree !== 'undefined' ) {
+            urlString += conf.subtree;
+        }
+        urlString += "::";
+        if( typeof conf.classes !== 'undefined' ) {
+            urlString += conf.classes;
+        }
+        urlString += "?ContentType=json";
+
         Y.one(conf.inputSelector).plug(Y.Plugin.AutoComplete, {
             maxResults: conf.resultLimit,
             minQueryLength: conf.minQueryLength,
@@ -29,7 +40,7 @@ YUI.add('ezfindautocomplete', function (Y) {
             },
             source: ds,
             // This will be appended to the URL that was supplied to the DataSource's "source" config above.
-            requestTemplate: "::{query}::" + conf.resultLimit + "?ContentType=json",
+            requestTemplate: urlString,
             // Custom result list locator to parse the results out of the response.
             resultListLocator: function (response) {
                 if (response && response[0] && response[0].responseText){


### PR DESCRIPTION
Replaces https://github.com/ezsystems/ezfind/pull/106

Note that this adds the capability to eZ Find. The various templates (object relations, Online Editor) still need to be updated if they want to use it. (Example: https://github.com/ezsystems/ezpublish-legacy/pull/620)