### PR TITLE
Solr redundant-write solution

### DIFF
--- a/classes/ezsolrbase.php
+++ b/classes/ezsolrbase.php
@@ -45,6 +45,12 @@ class eZSolrBase
      */
     var $SearchServerURI;
 
+    /**
+     * The solr update servers List
+     * @var string
+     */
+    var $UpdateServerList;
+
     var $SolrINI;
 
     /**
@@ -73,6 +79,14 @@ class eZSolrBase
         else
         {
             $this->SearchServerURI = 'http://localhost:8983/solr';
+        }
+        if( $this->SolrINI->hasVariable( 'SolrBase', 'UpdateServerList' ) )
+        {
+            $this->UpdateServerList = $this->SolrINI->variable( 'SolrBase', 'UpdateServerList' );
+        }
+        else
+        {
+            $this->UpdateServerList = array( $this->SearchServerURI );
         }
 
     }
@@ -145,8 +159,25 @@ class eZSolrBase
      */
     protected function postQuery( $request, $postData, $contentType = self::DEFAULT_REQUEST_CONTENTTYPE )
     {
-        $url = $this->SearchServerURI . $request;
-        return $this->sendHTTPRequestRetry( $url, $postData, $contentType );
+        if( $request == '/update' )
+        {
+            $result = false;
+            foreach( $this->UpdateServerList as $serverURI )
+            {
+                $url = $serverURI . $request;
+                $httpRequest = $this->sendHTTPRequestRetry( $url, $postData, $contentType );
+                if( $httpRequest !== false )
+                {
+                    $result = $httpRequest;
+                }
+            }
+            return $result;
+        }
+        else
+        {
+            $url = $this->SearchServerURI . $request;
+            return $this->sendHTTPRequestRetry( $url, $postData, $contentType );
+        }
     }
 
     /**

--- a/settings/solr.ini
+++ b/settings/solr.ini
@@ -15,6 +15,8 @@
 [SolrBase]
 # Base URI of the Solr server
 SearchServerURI=http://localhost:8983/solr
+# Solr replication server list, if specified, solr will index directly to all those solr instances, example ( UpdateServerList[]=http://localhost:8984/solr )
+# UpdateServerList[]
 # Solr connection timeout in seconds
 ConnectionTimeout=10
 # Solr read/send timeout in seconds, for larger indexes increase this to accomodate long optimize and/or commit processing


### PR DESCRIPTION
This patch allows ezfind to update a list of solr instances at once, so this is basically a distributed-write-to-solr modification.
