### PR TITLE
Fix EZP-23681: Delayed indexing of subtree on move

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1461,12 +1461,13 @@ class eZSolr implements ezpSearchEngine
      * @param $mainNodeID
      * @param $objectID
      * @param $nodeAssignmentIDList
+     * @param bool $isMoved true if node is being moved
      * @return unknown_type
      * @see eZSearch::addNodeAssignment()
      */
-    public function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList )
+    public function addNodeAssignment( $mainNodeID, $objectID, $nodeAssignmentIDList, $isMoved )
     {
-        eZContentOperationCollection::registerSearchObject( $objectID );
+        eZContentOperationCollection::registerSearchObject( $objectID, null, $isMoved );
     }
 
     /**


### PR DESCRIPTION
Updated addNodeAssignment's signature to add the isMoved Param

Follow up of https://github.com/ezsystems/ezpublish-legacy/pull/1119

Actually I had this fix locally and should have commited it earlier.
