### PR TITLE
Fix EZP-23840: Incorrect error handling in elevate configuration

### DIFF
--- a/classes/ezfindelevateconfiguration.php
+++ b/classes/ezfindelevateconfiguration.php
@@ -461,7 +461,6 @@ class eZFindElevateConfiguration extends eZPersistentObject
         elseif ( isset( $result['error'] ) )
         {
             eZDebug::writeError( $result['error'], __METHOD__ );
-            throw new Exception( $result['error'] );
         }
         else
         {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23840

Since SOLR 4.0+, error responses return an "error" structure (/array/object),
which can cause a fatal error when throwing a PHP exception with this non-string value.

This fixes it by using the appropriate error message key (`msg`) if applicable.

(see also: https://issues.apache.org/jira/browse/SOLR-141 )