### PR TITLE
Fix EZP-23617: Support content class IDs as filters

### DIFF
--- a/classes/ezfindservercallfunctions.php
+++ b/classes/ezfindservercallfunctions.php
@@ -175,7 +175,7 @@ class eZFindServerCallFunctions
                 $classQueryParts = array();
                 foreach( $classes as $class )
                 {
-                    if ( is_string( $class ) )
+                    if ( !is_numeric( $class ) )
                     {
                         if ( $class = eZContentClass::fetchByIdentifier( $class ) )
                         {


### PR DESCRIPTION
Bug fix for https://github.com/ezsystems/ezfind/pull/180 where the is_string check for a content class filter would always match when an integer was passed.  This is fixed by testing !is_numeric instead.