### PR TITLE
Fix EZP-24021: Link is wrong with non-main nodes using 'subtree_array'

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -328,7 +328,8 @@ class eZSolr implements ezpSearchEngine
             {
                 array_unshift( $docVisibilities, $docVisibilities[$mainNodeIdx] );
                 array_unshift( $docPathStrings, $docPathStrings[$mainNodeIdx] );
-                unset( $docVisibilities[$mainNodeIdx], $docPathStrings[$mainNodeIdx] );
+                // adding +1 to indexing because of array_unshift
+                unset( $docVisibilities[$mainNodeIdx + 1], $docPathStrings[$mainNodeIdx + 1] );
             }
         }
         $locationFilter = isset( $this->postSearchProcessingData['subtree_array'] ) ? $this->postSearchProcessingData['subtree_array'] : array();


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24021

## Description
When displaying an object that has more than one position, when displaying a node that is not the main one, the link provided is not the right one . This is because the offset used to select the solr doc representing the node is wrong.

Note: The customer who reported this issue and provided this patch said it introduced some side effects. I was not able to find any. We asked for some feedback but he didn't reply yet.

## Test
Manual test