### PR TITLE
Fix EZP-21831: eZFind: customfields with asObject=false

### DIFF
--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1670,7 +1670,7 @@ class eZSolr implements ezpSearchEngine
                     $emit = array();
                     foreach ( $doc as $fieldName => $fieldValue )
                     {
-                        // check if field is not in the explicit field list, to keep explode from generating notices.
+                        // check if fieldName contains an _, to keep list() from generating notices.
                         if ( strpos( $fieldName, '_' ) !== false )
                         {
                             list( $prefix, $rest ) = explode( '_', $fieldName, 2 );

--- a/search/plugins/ezsolr/ezsolr.php
+++ b/search/plugins/ezsolr/ezsolr.php
@@ -1684,14 +1684,14 @@ class eZSolr implements ezpSearchEngine
                             {
                                 $emit['data_map'][$inner] = ezfSolrStorage::unserializeData( $fieldValue );
                             }
-                        }
-                        // it may be a field originating from the explicit fieldlist to return, so it should be added for template consumption
-                        // note that the fieldname will be kept verbatim in a substructure 'fields'
-                        elseif( in_array( $fieldName, $params['FieldsToReturn'] ) )
-                        {
-                            $emit['fields'][$fieldName] = $fieldValue;
-                        }
 
+                            // it may be a field originating from the explicit fieldlist to return, so it should be added for template consumption
+                            // note that the fieldname will be kept verbatim in a substructure 'fields'
+                            elseif ( in_array( $fieldName, $params['FieldsToReturn'] ) )
+                            {
+                                $emit['fields'][$fieldName] = $fieldValue;
+                            }
+                        }
                     }
                     $emit['highlight'] = isset( $highLights[$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'guid' )]] ) ?
                                          $highLights[$doc[ezfSolrDocumentFieldBase::generateMetaFieldName( 'guid' )]] : null;


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21831

## Description
In https://github.com/ezsystems/ezfind/commit/931d3236c7ed3f6682f68f151f91a568567ba185?diff=split a condition has been added to avoid notices. Unfortunately the `if` statement added has been closed too early, preventing `$fieldsToReturn` from being processed.

## Tests
Manual tests