### PR TITLE
Fix EZP-24553: no results for exact phrases with camelCase words

### DIFF
--- a/java/solr/ezp-default/conf/language-specific-fieldtypes.xml
+++ b/java/solr/ezp-default/conf/language-specific-fieldtypes.xml
@@ -13,7 +13,7 @@
                 words="stopwords.txt"
                 enablePositionIncrements="true"
                 />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24553

When performing an exact match for some phrases, no results are returned.

#### Problem: ####
After investigation it seems the cause of the problem is caused by the existence of "camelCase" words in the sentence (eg: `eZ`)

The wordDelimiter filter in the `index` analyzer performs `splitOnCaseChange` and `concatenateWords` ( which causes "eZ Publish Platform" to be indexed as "e / ez / z | publish | platform" );
However, the `query` analyzer does not perform these operations, so the terms end up being different and not matching.

#### Solution: ####
Changing either the index or query analyzers to the same camelCase splitting behavior.

ping @paulborgermans 