### PR TITLE
EZP-27738: Return the field name as field value in facet_fields list

### DIFF
--- a/classes/ezfsearchresultinfo.php
+++ b/classes/ezfsearchresultinfo.php
@@ -226,7 +226,7 @@ class ezfSearchResultInfo
 
                         default:
                         {
-                            $fieldInfo = array( 'field' => $attr,
+                            $fieldInfo = array( 'field' => $field,
                                                 'count' => count( $facetField ),
                                                 'queryLimit' => array(),
                                                 'fieldList' => array(),


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-27738

See there for an explanation. Basically it will return the field in the field key. Before this patch it was always returning "facet_fields". 