### PR TITLE
Calling parent constructor correctly for 2017.10 / PHP7 compatibility 

### DIFF
--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -12,7 +12,7 @@ class eZFindResultNode extends eZContentObjectTreeNode
     */
     function eZFindResultNode( $rows = array() )
     {
-        $this->eZContentObjectTreeNode( $rows );
+        parent::__construct( $rows );
         if ( isset( $rows['id'] ) )
         {
             $this->ContentObjectID = $rows['id'];

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "ezsystems/ezpublish-legacy-installer": "*"
+        "ezsystems/ezpublish-legacy-installer": "*",
+        "ezsystems/ezpublish-legacy": ">=2017.10"
     },
     "extra": {
         "ezpublish-legacy-extension-name": "ezfind"


### PR DESCRIPTION
It's a follow up of
ezsystems/ezpublish-legacy#1233

Currently ezfind will through a fatal error search for an object.

*Testing instructions*
- in the admin interface do a search that will return result entries
- without this patch it will result in a PHP fatal error
- with this patch it will just show the result objects and there is no PHP fatal error