### PR TITLE
Avoid error.log entries eZUser::attribute:Attribute 'id' does not exists

### DIFF
--- a/classes/solrstorage/ezusersolrstorage.php
+++ b/classes/solrstorage/ezusersolrstorage.php
@@ -21,7 +21,7 @@ class ezuserSolrStorage extends ezdatatypeSolrStorage
         $user = eZUser::fetch( $contentObjectAttribute->attribute( "contentobject_id" ) );
         return array(
             'content' => array(
-                'id' => $user->attribute( 'id' ),
+                'id' => $user->attribute( 'contentobject_id' ),
                 'login' => $user->attribute( 'login' ),
                 'email' => $user->attribute( 'email' ),
             ),


### PR DESCRIPTION
eZUser has no attribute 'id' so we have to access 'contentobject_id'