### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/bin/php/updatesearchindexsolr.php
+++ b/bin/php/updatesearchindexsolr.php
@@ -61,7 +61,7 @@ class ezfUpdateSearchIndexSolr
      * @param eZCLI $cli
      * @param string $executedScript
      */
-    function ezfUpdateSearchIndexSolr( eZScript $script, eZCLI $cli, $executedScript )
+    function __construct( eZScript $script, eZCLI $cli, $executedScript )
     {
         $this->Script = $script;
         $this->CLI = $cli;

--- a/classes/ezfezpsolrquerybuilder.php
+++ b/classes/ezfezpsolrquerybuilder.php
@@ -14,7 +14,7 @@ class ezfeZPSolrQueryBuilder
      * @param Object $searchPluginInstance Search engine instance. Allows the query builder to
      *        communicate with the caller ( eZSolr instance ).
      */
-    function ezfeZPSolrQueryBuilder( $searchPluginInstance )
+    function __construct( $searchPluginInstance )
     {
         $this->searchPluginInstance = $searchPluginInstance;
     }

--- a/classes/ezfindresultnode.php
+++ b/classes/ezfindresultnode.php
@@ -10,7 +10,7 @@ class eZFindResultNode extends eZContentObjectTreeNode
     /*!
      \reimp
     */
-    function eZFindResultNode( $rows = array() )
+    function __construct( $rows = array() )
     {
         parent::__construct( $rows );
         if ( isset( $rows['id'] ) )

--- a/classes/ezfindresultobject.php
+++ b/classes/ezfindresultobject.php
@@ -10,7 +10,7 @@ class eZFindResultObject extends eZContentObject
     /*!
      \reimp
     */
-    function eZFindResultObject( $rows = array() )
+    function __construct( $rows = array() )
     {
         $this->LocalAttributeValueList = array();
         $this->LocalAttributeNameList = array( 'published' );

--- a/classes/ezfmodulefunctioncollection.php
+++ b/classes/ezfmodulefunctioncollection.php
@@ -14,7 +14,7 @@ class ezfModuleFunctionCollection
     /**
      * Constructor
      */
-    function ezfModuleFunctionCollection()
+    function __construct()
     {
     }
 

--- a/classes/ezfsearchresultinfo.php
+++ b/classes/ezfsearchresultinfo.php
@@ -24,7 +24,7 @@ class ezfSearchResultInfo
      *           'Engine' => 'engine name',
      *           ... )
      */
-    function ezfSearchResultInfo( array $resultArray )
+    function __construct( array $resultArray )
     {
         $this->ResultArray = $resultArray;
     }


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.0 | /bin/php/updatesearchindexsolr.php:64                                                              | method_name      | Method name ezfUpdateSearchIndexSolr:ezfUpdateSearchIndexSolr (@php4_constructors) is deprecated. 
 7.0 | /classes/ezfezpsolrquerybuilder.php:17                                                             | method_name      | Method name ezfeZPSolrQueryBuilder:ezfeZPSolrQueryBuilder (@php4_constructors) is deprecated. 
 7.0 | /classes/ezfindresultnode.php:13                                                                   | method_name      | Method name eZFindResultNode:eZFindResultNode (@php4_constructors) is deprecated. 
 7.0 | /classes/ezfindresultobject.php:13                                                                 | method_name      | Method name eZFindResultObject:eZFindResultObject (@php4_constructors) is deprecated. 
 7.0 | /classes/ezfmodulefunctioncollection.php:17                                                        | method_name      | Method name ezfModuleFunctionCollection:ezfModuleFunctionCollection (@php4_constructors) is deprecated. 
 7.0 | /classes/ezfsearchresultinfo.php:27                                                                | method_name      | Method name ezfSearchResultInfo:ezfSearchResultInfo (@php4_constructors) is deprecated. 
```
